### PR TITLE
Added rgb support, one file for launching compression of both streams at the same time

### DIFF
--- a/libav_compressor/launch/depth_loader.launch
+++ b/libav_compressor/launch/depth_loader.launch
@@ -1,0 +1,4 @@
+<launch>
+	<node pkg="libav_compressor" type="batch_decompressor.py" name="batch_decompressor" args="$(find libav_compressor)/images" output="screen"/>
+e>
+</launch>

--- a/libav_compressor/launch/depth_saver.launch
+++ b/libav_compressor/launch/depth_saver.launch
@@ -1,5 +1,5 @@
 <launch>
-    <node pkg="openni_saver" type="synch_saver_node" name="synch_saver_node" output="screen">
+    <node pkg="openni_saver" type="depth_saver_node" name="depth_saver_node" output="screen">
         <param name="image_folder" value="$(find openni_saver)/images"/>
     </node>
 	<node pkg="libav_compressor" type="batch_compressor.py" name="batch_compressor" args="$(find openni_saver)/images" output="screen"/>

--- a/libav_compressor/launch/video_loader.launch
+++ b/libav_compressor/launch/video_loader.launch
@@ -1,4 +1,0 @@
-<launch>
-	<node pkg="libav_compressor" type="batch_decompressor.py" name="batch_decompressor" args="$(find libav_compressor)/images" output="screen"/>
-e>
-</launch>

--- a/libav_compressor/scripts/batch_compressor.py
+++ b/libav_compressor/scripts/batch_compressor.py
@@ -8,21 +8,30 @@ def callback(sc, impath, nbr):
     temps = []
     counter = 0
     flist = os.listdir(impath)
-    flist.sort(key = lambda s: (s[:-10], int(s[-10:-4])))
+    flist = filter(lambda s: s[:5] == "depth", flist)
+    flist.sort(key = lambda s: int(s[-10:-4]))
     for f in flist:
-        if not os.path.isfile(os.path.join(impath, f)):
+        if not os.path.isfile(os.path.join(impath, f)): # should not happen
             continue
-        if f[:5] != "depth":
-            continue
-        tempname = os.path.join(impath, "tempdepth%06d.png" % counter)
-        os.rename(os.path.join(impath, f), tempname)
-        #shutil.copy(tempname, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, "debug", f))) # for debugging, saving the original images
-        temps.append(tempname)
+        #if f[:5] != "depth":
+            #continue
+        depthtemp = os.path.join(impath, "tempdepth%06d.png" % counter)
+        rgbtemp = os.path.join(impath, "temprgb%06d.png" % counter)
+        rgbf = "rgb" + f[-10:-4] + ".png"
+        os.rename(os.path.join(impath, f), depthtemp) # check if there really are depths coming in
+        os.rename(os.path.join(impath, rgbf), rgbtemp) # check if there really are rgbs coming in
+        #shutil.copy(depthtemp, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, "debug", f))) # for debugging, saving the original images
+        #shutil.copy(rgbtemp, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, "debug", rgbf))) # for debugging, saving the original images
+        temps.append(depthtemp)
+        temps.append(rgbtemp)
         counter += 1
     depthimages = os.path.join(impath, "tempdepth%06d.png")
+    rgbimages = os.path.join(impath, "temprgb%06d.png")
     avconv = os.path.abspath(os.path.join(os.path.expanduser('~'), "libav", "bin", "avconv"))
-    video = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, "videos", "depth%06d.mov" % nbr))
-    os.system("%s -r 30 -i %s -pix_fmt gray16 -vsync 1 -vcodec ffv1 -coder 1 %s" % (avconv, depthimages, video))
+    depthvideo = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, "videos", "depth%06d.mov" % nbr))
+    rgbvideo = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, "videos", "rgb%06d.mov" % nbr))
+    os.system("%s -r 30 -i %s -pix_fmt gray16 -vsync 1 -vcodec ffv1 -coder 1 %s" % (avconv, depthimages, depthvideo))
+    os.system("%s -r 30 -i %s -c:v libx264 -preset ultrafast -crf 0 %s" % (avconv, rgbimages, rgbvideo))
     for f in temps:
         os.remove(f)
 

--- a/openni_saver/CMakeLists.txt
+++ b/openni_saver/CMakeLists.txt
@@ -75,6 +75,7 @@ add_library(cv_saver src/cv_saver.cpp)
 # add_executable(xtion_saver src/xtion_saver.cpp)
 add_executable(depth_saver_node src/depth_saver_node.cpp)
 add_executable(rgb_saver_node src/rgb_saver_node.cpp)
+add_executable(synch_saver_node src/synch_saver_node.cpp)
 
 ## Add cmake target dependencies of the executable/library
 ## as an example, message headers may need to be generated before nodes
@@ -93,10 +94,15 @@ target_link_libraries(rgb_saver_node
    ${catkin_LIBRARIES}
 )
 
+target_link_libraries(synch_saver_node
+   ${catkin_LIBRARIES}
+)
+
 target_link_libraries(cv_saver opencv_calib3d opencv_core opencv_flann opencv_highgui opencv_legacy opencv_nonfree opencv_photo opencv_ts opencv_videostab opencv_contrib opencv_features2d opencv_gpu  opencv_imgproc opencv_ml opencv_objdetect opencv_stitching opencv_video cv_bridge)
 
 target_link_libraries(depth_saver_node cv_saver)
 target_link_libraries(rgb_saver_node cv_saver)
+target_link_libraries(synch_saver_node cv_saver)
 
 #############
 ## Install ##

--- a/openni_saver/src/cv_saver.cpp
+++ b/openni_saver/src/cv_saver.cpp
@@ -40,7 +40,10 @@ namespace cv_saver {
 		}
 		//std::cout << cv_img_boost_ptr->image.type() << std::endl;
 		//std::cout << CV_32FC1 << std::endl;
-		cv::imwrite(buffer, cv_img_boost_ptr->image);
+        std::vector<int> compression;
+        compression.push_back(CV_IMWRITE_PNG_COMPRESSION);
+        compression.push_back(0);
+		cv::imwrite(buffer, cv_img_boost_ptr->image, compression);
 	}
 
 }

--- a/openni_saver/src/cv_saver.cpp
+++ b/openni_saver/src/cv_saver.cpp
@@ -1,6 +1,5 @@
 #include "cv_saver.h"
 
-#include <opencv.hpp>
 #include <cv_bridge/cv_bridge.h>
 #include <ros/ros.h>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
@@ -11,6 +10,8 @@ namespace cv_saver {
 	void init_saver(const std::string& path)
 	{
         impath = path;
+        gotDepth = false;
+        gotRGB = false;
 		boost::posix_time::ptime time = boost::posix_time::microsec_clock::local_time();
 		boost::posix_time::time_duration duration(time.time_of_day());
 		start = duration.total_milliseconds();
@@ -38,12 +39,69 @@ namespace cv_saver {
 			std::cout << "Received an RGB image!" << std::endl;
 			sprintf(buffer, "%s/rgb%06d.png", impath.c_str(), int(duration.total_milliseconds() - start));
 		}
-		//std::cout << cv_img_boost_ptr->image.type() << std::endl;
-		//std::cout << CV_32FC1 << std::endl;
         std::vector<int> compression;
         compression.push_back(CV_IMWRITE_PNG_COMPRESSION);
         compression.push_back(0);
 		cv::imwrite(buffer, cv_img_boost_ptr->image, compression);
+	}
+
+	void synch_callback(const sensor_msgs::Image::ConstPtr& msg)
+	{
+	    boost::shared_ptr<sensor_msgs::Image> tracked_object;
+		cv_bridge::CvImageConstPtr cv_img_boost_ptr;
+		try {
+			cv_img_boost_ptr = cv_bridge::toCvShare(*msg, tracked_object);
+		}
+		catch (cv_bridge::Exception& e) {
+			ROS_ERROR("cv_bridge exception: %s", e.what());
+			return;
+		}
+		boost::posix_time::ptime time = boost::posix_time::microsec_clock::local_time();
+	    boost::posix_time::time_duration duration(time.time_of_day());
+	    int delta;
+	    char buffer[250];
+	    if (cv_img_boost_ptr->image.type() == CV_16UC1) {
+            if (gotRGB) {
+                std::cout << "Received a depth image!" << std::endl;
+                delta = duration.total_milliseconds() - start;
+			    sprintf(buffer, "%s/depth%06d.png", impath.c_str(), delta);
+			    std::vector<int> compression;
+                compression.push_back(CV_IMWRITE_PNG_COMPRESSION);
+                compression.push_back(0);
+		        cv::imwrite(buffer, cv_img_boost_ptr->image, compression);
+		        sprintf(buffer, "%s/rgb%06d.png", impath.c_str(), delta);
+		        cv::imwrite(buffer, lastRGB, compression);
+		        gotRGB = false;
+		        gotDepth = false;
+            }
+            else {
+                std::cout << "Now i set depth!" << std::endl;
+                lastDepth = cv_img_boost_ptr->image.clone();
+                gotDepth = true;
+            }
+		}
+		else if (cv_img_boost_ptr->image.type() == CV_8UC3) {
+		    if (gotRGB) {
+			    std::cout << "Received an RGB image!" << std::endl;
+			    delta = duration.total_milliseconds() - start;
+			    sprintf(buffer, "%s/rgb%06d.png", impath.c_str(), delta);
+			    std::vector<int> compression;
+                compression.push_back(CV_IMWRITE_PNG_COMPRESSION);
+                compression.push_back(0);
+		        cv::imwrite(buffer, cv_img_boost_ptr->image, compression);
+		        sprintf(buffer, "%s/depth%06d.png", impath.c_str(), delta);
+		        cv::imwrite(buffer, lastDepth, compression);
+		        gotRGB = false;
+		        gotDepth = false;
+            }
+            else {
+                std::cout << "Now i set rgb!" << std::endl;
+                lastRGB = cv_img_boost_ptr->image.clone();
+                gotRGB = true;
+            }
+
+		}
+        
 	}
 
 }

--- a/openni_saver/src/cv_saver.h
+++ b/openni_saver/src/cv_saver.h
@@ -3,13 +3,19 @@
 
 #include <sensor_msgs/Image.h>
 #include <string>
+#include <opencv.hpp>
 
 namespace cv_saver {
 
+    cv::Mat lastDepth;
+    cv::Mat lastRGB;
+    bool gotDepth;
+    bool gotRGB;
     std::string impath;
 	long int start;
 	void init_saver(const std::string&);
 	void image_callback(const sensor_msgs::Image::ConstPtr& msg);
+    void synch_callback(const sensor_msgs::Image::ConstPtr& msg);
 	
 }
 #endif


### PR DESCRIPTION
Association of frames is very primitive right now, it should keep a small buffer and associate based on the time stamps. The rgb compression uses libx264, instructions for download and installation are updated. It currently uses the ultrafast option which makes the files ~40% larger. This is done in order to make sure the compression is always running online. The fast option was not fast enough on my computer.
