### PR TITLE
Added timestamps to be able to recreate the stream later together with a rosbag

### DIFF
--- a/libav_compressor/launch/depth_loader.launch
+++ b/libav_compressor/launch/depth_loader.launch
@@ -1,4 +1,0 @@
-<launch>
-	<node pkg="libav_compressor" type="batch_decompressor.py" name="batch_decompressor" args="$(find libav_compressor)/images" output="screen"/>
-e>
-</launch>

--- a/libav_compressor/launch/depth_saver.launch
+++ b/libav_compressor/launch/depth_saver.launch
@@ -1,7 +1,0 @@
-<launch>
-    <node pkg="openni_saver" type="depth_saver_node" name="depth_saver_node" output="screen">
-        <param name="image_folder" value="$(find openni_saver)/images"/>
-    </node>
-	<node pkg="libav_compressor" type="batch_compressor.py" name="batch_compressor" args="$(find openni_saver)/images" output="screen"/>
-e>
-</launch>

--- a/libav_compressor/scripts/batch_compressor.py
+++ b/libav_compressor/scripts/batch_compressor.py
@@ -6,20 +6,24 @@ def callback(sc, impath, nbr):
     sc.enter(20, 1, callback, (sc, impath, nbr+1))
     print "Compressing..."
     temps = []
+    first = ""
     counter = 0
     flist = os.listdir(impath)
     flist = filter(lambda s: s[:5] == "depth", flist)
-    flist.sort(key = lambda s: int(s[-10:-4]))
+    flist.sort(key = lambda s: int(s[5:11]))
     for f in flist:
         if not os.path.isfile(os.path.join(impath, f)): # should not happen
             continue
         #if f[:5] != "depth":
             #continue
+        if counter == 0:
+            first = f[12:21]
         depthtemp = os.path.join(impath, "tempdepth%06d.png" % counter)
         rgbtemp = os.path.join(impath, "temprgb%06d.png" % counter)
-        rgbf = "rgb" + f[-10:-4] + ".png"
+        rgbf = "rgb" + f[5:11] + "-*.png"
         os.rename(os.path.join(impath, f), depthtemp) # check if there really are depths coming in
-        os.rename(os.path.join(impath, rgbf), rgbtemp) # check if there really are rgbs coming in
+        os.system("mv %s %s" % (os.path.join(impath, rgbf), rgbtemp))
+        #os.rename(os.path.join(impath, rgbf), rgbtemp) # check if there really are rgbs coming in
         #shutil.copy(depthtemp, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, "debug", f))) # for debugging, saving the original images
         #shutil.copy(rgbtemp, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, "debug", rgbf))) # for debugging, saving the original images
         temps.append(depthtemp)
@@ -28,8 +32,8 @@ def callback(sc, impath, nbr):
     depthimages = os.path.join(impath, "tempdepth%06d.png")
     rgbimages = os.path.join(impath, "temprgb%06d.png")
     avconv = os.path.abspath(os.path.join(os.path.expanduser('~'), "libav", "bin", "avconv"))
-    depthvideo = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, "videos", "depth%06d.mov" % nbr))
-    rgbvideo = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, "videos", "rgb%06d.mov" % nbr)) # maybe this has to be mkv??
+    depthvideo = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, "videos", "depth%s.mov" % first))
+    rgbvideo = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, "videos", "rgb%s.mov" % first)) # maybe this has to be mkv??
     os.system("%s -r 30 -i %s -pix_fmt gray16 -vsync 1 -vcodec ffv1 -coder 1 %s" % (avconv, depthimages, depthvideo))
     os.system("%s -r 30 -i %s -c:v libx264 -preset ultrafast -crf 0 %s" % (avconv, rgbimages, rgbvideo))
     for f in temps:

--- a/libav_compressor/scripts/batch_compressor.py
+++ b/libav_compressor/scripts/batch_compressor.py
@@ -18,6 +18,9 @@ def callback(sc, impath, nbr):
             #continue
         if counter == 0:
             first = f[12:21]
+            timepath = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, "videos", "time%s.txt" % first))
+            timef = open(timepath, 'w')
+        timef.write(f[5:31] + '\n')
         depthtemp = os.path.join(impath, "tempdepth%06d.png" % counter)
         rgbtemp = os.path.join(impath, "temprgb%06d.png" % counter)
         rgbf = "rgb" + f[5:11] + "-*.png"
@@ -29,6 +32,7 @@ def callback(sc, impath, nbr):
         temps.append(depthtemp)
         temps.append(rgbtemp)
         counter += 1
+    timef.close()
     depthimages = os.path.join(impath, "tempdepth%06d.png")
     rgbimages = os.path.join(impath, "temprgb%06d.png")
     avconv = os.path.abspath(os.path.join(os.path.expanduser('~'), "libav", "bin", "avconv"))

--- a/libav_compressor/scripts/batch_compressor.py
+++ b/libav_compressor/scripts/batch_compressor.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import sched, time, os, sys
-#import shutil # for debugging, saving the original images
+import shutil # for debugging, saving the original images
 
 def callback(sc, impath, nbr):
     sc.enter(20, 1, callback, (sc, impath, nbr+1))
@@ -17,18 +17,17 @@ def callback(sc, impath, nbr):
         #if f[:5] != "depth":
             #continue
         if counter == 0:
-            first = f[12:21]
+            first = f[12:22]
             timepath = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, "videos", "time%s.txt" % first))
             timef = open(timepath, 'w')
-        timef.write(f[5:31] + '\n')
+        timef.write(f[5:33] + '\n')
         depthtemp = os.path.join(impath, "tempdepth%06d.png" % counter)
         rgbtemp = os.path.join(impath, "temprgb%06d.png" % counter)
         rgbf = "rgb" + f[5:11] + "-*.png"
         os.rename(os.path.join(impath, f), depthtemp) # check if there really are depths coming in
         os.system("mv %s %s" % (os.path.join(impath, rgbf), rgbtemp))
         #os.rename(os.path.join(impath, rgbf), rgbtemp) # check if there really are rgbs coming in
-        #shutil.copy(depthtemp, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, "debug", f))) # for debugging, saving the original images
-        #shutil.copy(rgbtemp, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, "debug", rgbf))) # for debugging, saving the original images
+        shutil.copy(depthtemp, os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, "debug", f))) # for debugging, saving the original images
         temps.append(depthtemp)
         temps.append(rgbtemp)
         counter += 1

--- a/libav_compressor/scripts/batch_decompressor.py
+++ b/libav_compressor/scripts/batch_decompressor.py
@@ -22,8 +22,6 @@ def batch_decompressor(impath):
         templist = filter(lambda s: s[:9] == "tempdepth", templist)
         templist.sort(key = lambda s: int(s[-11:-5]))
         for t in templist:
-            print "Depth file name"
-            print t[-11:5]
             rgbt = os.path.join(impath, "temprgb" + t[-11:-5] + ".png")
             os.rename(os.path.join(impath, t), os.path.join(impath, "depth%06d.tiff" % counter))
             os.rename(rgbt, os.path.join(impath, "rgb%06d.png" % counter))

--- a/libav_compressor/scripts/batch_decompressor.py
+++ b/libav_compressor/scripts/batch_decompressor.py
@@ -7,13 +7,13 @@ def batch_decompressor(impath):
     counter = 0
     flist = os.listdir(vidpath)
     flist = filter(lambda s: s[:5] == "depth", flist)
-    flist.sort(key = lambda s: int(s[5:14]))
+    flist.sort(key = lambda s: int(s[5:15]))
     for f in flist:
         depthvid = os.path.join(vidpath, f)
         if not os.path.isfile(depthvid):
             continue
-        rgbvid = os.path.join(vidpath, "rgb" + f[5:14] + ".mov") # should this be mkv?
-        timef = open(os.path.join(vidpath, "time" + f[5:14] + ".txt"), 'r')
+        rgbvid = os.path.join(vidpath, "rgb" + f[5:15] + ".mov") # should this be mkv?
+        timef = open(os.path.join(vidpath, "time" + f[5:15] + ".txt"), 'r')
         depthimages = os.path.join(impath, "tempdepth%06d.tiff")
         rgbimages = os.path.join(impath, "temprgb%06d.png")
         avconv = os.path.abspath(os.path.join(os.path.expanduser('~'), "libav", "bin", "avconv"))

--- a/libav_compressor/scripts/batch_decompressor.py
+++ b/libav_compressor/scripts/batch_decompressor.py
@@ -13,6 +13,7 @@ def batch_decompressor(impath):
         if not os.path.isfile(depthvid):
             continue
         rgbvid = os.path.join(vidpath, "rgb" + f[5:14] + ".mov") # should this be mkv?
+        timef = open(os.path.join(vidpath, "time" + f[5:14] + ".txt"), 'r')
         depthimages = os.path.join(impath, "tempdepth%06d.tiff")
         rgbimages = os.path.join(impath, "temprgb%06d.png")
         avconv = os.path.abspath(os.path.join(os.path.expanduser('~'), "libav", "bin", "avconv"))
@@ -22,10 +23,12 @@ def batch_decompressor(impath):
         templist = filter(lambda s: s[:9] == "tempdepth", templist)
         templist.sort(key = lambda s: int(s[-11:-5]))
         for t in templist:
+            time = timef.readline()
             rgbt = os.path.join(impath, "temprgb" + t[-11:-5] + ".png")
-            os.rename(os.path.join(impath, t), os.path.join(impath, "depth%06d.tiff" % counter))
-            os.rename(rgbt, os.path.join(impath, "rgb%06d.png" % counter))
+            os.rename(os.path.join(impath, t), os.path.join(impath, "depth%s.tiff" % time))
+            os.rename(rgbt, os.path.join(impath, "rgb%s.png" % time))
             counter += 1
+        timef.close()
 
 if __name__ == "__main__":
     batch_decompressor(sys.argv[1])

--- a/libav_compressor/scripts/batch_decompressor.py
+++ b/libav_compressor/scripts/batch_decompressor.py
@@ -7,12 +7,12 @@ def batch_decompressor(impath):
     counter = 0
     flist = os.listdir(vidpath)
     flist = filter(lambda s: s[:5] == "depth", flist)
-    flist.sort(key = lambda s: (s[:-10], int(s[-10:-4])))
+    flist.sort(key = lambda s: int(s[5:14]))
     for f in flist:
         depthvid = os.path.join(vidpath, f)
         if not os.path.isfile(depthvid):
             continue
-        rgbvid = os.path.join(vidpath, "rgb" + f[-10:-4] + ".mov") # should this be mkv?
+        rgbvid = os.path.join(vidpath, "rgb" + f[5:14] + ".mov") # should this be mkv?
         depthimages = os.path.join(impath, "tempdepth%06d.tiff")
         rgbimages = os.path.join(impath, "temprgb%06d.png")
         avconv = os.path.abspath(os.path.join(os.path.expanduser('~'), "libav", "bin", "avconv"))

--- a/libav_compressor/src/test_quality.cpp
+++ b/libav_compressor/src/test_quality.cpp
@@ -20,6 +20,8 @@ int main(int argc, char** argv) {
 	Mat cvMat2 = Mat::zeros(480, 640, CV_16UC1);
 	std::string dirname1(argv[1]);
 	std::string dirname2(argv[2]);
+	
+	std::string depthName("depth");
 
     DIR* dir = opendir(dirname1.c_str());
     if (dir == NULL) {
@@ -29,7 +31,11 @@ int main(int argc, char** argv) {
     std::vector<std::string> entries1;
     struct dirent* ent;
     while ((ent = readdir(dir)) != NULL) {
-        entries1.push_back(std::string(ent->d_name));
+        std::string entry(ent->d_name);
+        if (entry.compare(0, depthName.size(), depthName) != 0) {
+	        continue;
+	    }
+        entries1.push_back(entry);
     }
     closedir(dir);
 
@@ -40,24 +46,28 @@ int main(int argc, char** argv) {
     }
     std::vector<std::string> entries2;
     while ((ent = readdir(dir)) != NULL) {
-        entries2.push_back(std::string(ent->d_name));
+        std::string entry(ent->d_name);
+        if (entry.compare(0, depthName.size(), depthName) != 0) {
+	        continue;
+	    }
+        entries2.push_back(entry);
     }
     closedir(dir);
 
     std::sort(entries1.begin(), entries1.end());
     std::sort(entries2.begin(), entries2.end());
-
-	std::string depthName("depth");
-    for (int i = 2; i < entries2.size(); ++i) {
+    
+    for (int i = 0; i < entries2.size(); ++i) {
     	std::string file1 = entries1[i];
     	std::string file2 = entries2[i];
     	std::cout << dirname1 + '/' + file1 << std::endl;
     	std::cout << dirname2 + '/' + file2 << std::endl;
         cvMat1 = imread(dirname1 + '/' + file1, -1);
-        cvMat2 = imread(dirname2 + '/' + file2, -1);
+        cvMat2 = imread(dirname2 + '/' + file2, -1); // should be same name!
         imshow("Original", 16*cvMat1);
+        imshow("Recreated", 16*cvMat2);
         Mat diff = 100*(cvMat2 - cvMat1);
-        displayDepth("First", diff);
+        displayDepth("Difference", diff);
         //displayDepth("Second", cvMat2);
         waitKey();
     }

--- a/openni_saver/src/cv_saver.cpp
+++ b/openni_saver/src/cv_saver.cpp
@@ -69,12 +69,12 @@ namespace cv_saver {
             if (!rgbs.empty()) {
                 std::cout << "Received a depth image!" << std::endl;
                 delta = duration.total_milliseconds() - start;
-			    sprintf(buffer, "%s/depth%06d-%09d-%09d.png", impath.c_str(), delta, sec, nsec);
+			    sprintf(buffer, "%s/depth%06d-%010d-%010d.png", impath.c_str(), delta, sec, nsec);
 			    std::vector<int> compression;
                 compression.push_back(CV_IMWRITE_PNG_COMPRESSION);
                 compression.push_back(0);
 		        cv::imwrite(buffer, cv_img_boost_ptr->image, compression);
-		        sprintf(buffer, "%s/rgb%06d-%09d-%09d.png", impath.c_str(), delta, rgb_secs.front(), rgb_nsecs.front());
+		        sprintf(buffer, "%s/rgb%06d-%010d-%010d.png", impath.c_str(), delta, rgb_secs.front(), rgb_nsecs.front());
 		        cv::imwrite(buffer, rgbs.front(), compression);
 		        rgbs.pop_front();
 		        rgb_secs.pop_front();
@@ -91,12 +91,12 @@ namespace cv_saver {
 		    if (!depths.empty()) {
 			    std::cout << "Received an RGB image!" << std::endl;
 			    delta = duration.total_milliseconds() - start;
-			    sprintf(buffer, "%s/rgb%06d-%09d-%09d.png", impath.c_str(), delta, sec, nsec);
+			    sprintf(buffer, "%s/rgb%06d-%010d-%010d.png", impath.c_str(), delta, sec, nsec);
 			    std::vector<int> compression;
                 compression.push_back(CV_IMWRITE_PNG_COMPRESSION);
                 compression.push_back(0);
 		        cv::imwrite(buffer, cv_img_boost_ptr->image, compression);
-		        sprintf(buffer, "%s/depth%06d-%09d-%09d.png", impath.c_str(), delta, depth_secs.front(), depth_nsecs.front());
+		        sprintf(buffer, "%s/depth%06d-%010d-%010d.png", impath.c_str(), delta, depth_secs.front(), depth_nsecs.front());
 		        cv::imwrite(buffer, depths.front(), compression);
 		        depths.pop_front();
 		        depth_secs.pop_front();

--- a/openni_saver/src/cv_saver.cpp
+++ b/openni_saver/src/cv_saver.cpp
@@ -19,6 +19,7 @@ namespace cv_saver {
 
 	void image_callback(const sensor_msgs::Image::ConstPtr& msg)
 	{
+	    std::cout << "Time lag = " << msg->header.stamp.sec << "." << msg->header.stamp.nsec << std::endl;
 		boost::shared_ptr<sensor_msgs::Image> tracked_object;
 		cv_bridge::CvImageConstPtr cv_img_boost_ptr;
 		try {
@@ -47,6 +48,7 @@ namespace cv_saver {
 
 	void synch_callback(const sensor_msgs::Image::ConstPtr& msg)
 	{
+	    std::cout << "Time lag = " << msg->header.stamp.sec << "." << msg->header.stamp.nsec << std::endl;
 	    boost::shared_ptr<sensor_msgs::Image> tracked_object;
 		cv_bridge::CvImageConstPtr cv_img_boost_ptr;
 		try {

--- a/openni_saver/src/cv_saver.cpp
+++ b/openni_saver/src/cv_saver.cpp
@@ -51,6 +51,7 @@ namespace cv_saver {
 	    int sec = msg->header.stamp.sec;
 	    int nsec = msg->header.stamp.nsec;
 	    std::cout << "Time lag = " << sec << "." << nsec << std::endl;
+	    std::cout << "Depths: " << depths.size() << " , RGBs: " << rgbs.size() << std::endl;
 	    boost::shared_ptr<sensor_msgs::Image> tracked_object;
 		cv_bridge::CvImageConstPtr cv_img_boost_ptr;
 		try {
@@ -68,14 +69,16 @@ namespace cv_saver {
             if (!rgbs.empty()) {
                 std::cout << "Received a depth image!" << std::endl;
                 delta = duration.total_milliseconds() - start;
-			    sprintf(buffer, "%s/depth%06d.png", impath.c_str(), delta);
+			    sprintf(buffer, "%s/depth%06d-%09d-%09d.png", impath.c_str(), delta, sec, nsec);
 			    std::vector<int> compression;
                 compression.push_back(CV_IMWRITE_PNG_COMPRESSION);
                 compression.push_back(0);
 		        cv::imwrite(buffer, cv_img_boost_ptr->image, compression);
-		        sprintf(buffer, "%s/rgb%06d.png", impath.c_str(), delta);
+		        sprintf(buffer, "%s/rgb%06d-%09d-%09d.png", impath.c_str(), delta, rgb_secs.front(), rgb_nsecs.front());
 		        cv::imwrite(buffer, rgbs.front(), compression);
 		        rgbs.pop_front();
+		        rgb_secs.pop_front();
+		        rgb_nsecs.pop_front();
             }
             else {
                 std::cout << "Now i set depth!" << std::endl;
@@ -88,14 +91,16 @@ namespace cv_saver {
 		    if (!depths.empty()) {
 			    std::cout << "Received an RGB image!" << std::endl;
 			    delta = duration.total_milliseconds() - start;
-			    sprintf(buffer, "%s/rgb%06d.png", impath.c_str(), delta);
+			    sprintf(buffer, "%s/rgb%06d-%09d-%09d.png", impath.c_str(), delta, sec, nsec);
 			    std::vector<int> compression;
                 compression.push_back(CV_IMWRITE_PNG_COMPRESSION);
                 compression.push_back(0);
 		        cv::imwrite(buffer, cv_img_boost_ptr->image, compression);
-		        sprintf(buffer, "%s/depth%06d.png", impath.c_str(), delta);
+		        sprintf(buffer, "%s/depth%06d-%09d-%09d.png", impath.c_str(), delta, depth_secs.front(), depth_nsecs.front());
 		        cv::imwrite(buffer, depths.front(), compression);
 		        depths.pop_front();
+		        depth_secs.pop_front();
+		        depth_nsecs.pop_front();
             }
             else {
                 std::cout << "Now i set rgb!" << std::endl;

--- a/openni_saver/src/cv_saver.h
+++ b/openni_saver/src/cv_saver.h
@@ -4,13 +4,16 @@
 #include <sensor_msgs/Image.h>
 #include <string>
 #include <opencv2/opencv.hpp>
+#include <list>
 
 namespace cv_saver {
 
-    cv::Mat lastDepth;
-    cv::Mat lastRGB;
-    bool gotDepth;
-    bool gotRGB;
+    std::list<cv::Mat> depths;
+    std::list<cv::Mat> rgbs;
+    std::list<int> depth_secs;
+    std::list<int> rgb_secs;
+    std::list<int> depth_nsecs;
+    std::list<int> rgb_nsecs;
     std::string impath;
 	long int start;
 	void init_saver(const std::string&);

--- a/openni_saver/src/synch_saver_node.cpp
+++ b/openni_saver/src/synch_saver_node.cpp
@@ -4,10 +4,6 @@
 
 int main(int argc, char** argv)
 {
-
-	//cv_saver saver;
-	std::cout << "WHAT!" << std::endl;
-	std::cout << "WHAT!" << std::endl;
 	ros::init(argc, argv, "synch_saver_node");
 	ros::NodeHandle n;
     if (!n.hasParam("/synch_saver_node/image_folder")) {
@@ -15,13 +11,10 @@ int main(int argc, char** argv)
         return -1;
     }
     std::string image_folder;
-    std::cout << "1" << std::endl;
     n.getParam("/synch_saver_node/image_folder", image_folder);
     cv_saver::init_saver(image_folder);
-    std::cout << "2" << std::endl;
     //ros::Duration(0.5).sleep();
 	ros::Subscriber depthSub = n.subscribe("camera/depth/image_raw", 10, &cv_saver::synch_callback);
-	std::cout << "3" << std::endl;
     ros::Subscriber rgbSub = n.subscribe("camera/rgb/image_color", 10, &cv_saver::synch_callback);
 	ros::spin();
 


### PR DESCRIPTION
This names the files (also intermediate video) to the ros timestamps of the messages. During video storage, timestamps are stored in separate text files. The association of depth and color should be slightly better now. The subscribed image topics should probably be some other ones. Also updated the quality test of the depth video to be able to run with the new names. Right now, the debug lines in batch_compressor.py are uncommented so you are still storing the images on your computer when running video_saver.launch. Next step is to see if we can use the time topic from a rosbag with simulated time to publish the topics at the same time as we received them together with the rosbag topics.
