### PR TITLE
Adding a new package for playing back video in conjunction with rosbag

### DIFF
--- a/libav_compressor/scripts/batch_decompressor.py
+++ b/libav_compressor/scripts/batch_decompressor.py
@@ -25,8 +25,8 @@ def batch_decompressor(impath):
         for t in templist:
             time = timef.readline()
             rgbt = os.path.join(impath, "temprgb" + t[-11:-5] + ".png")
-            os.rename(os.path.join(impath, t), os.path.join(impath, "depth%s.tiff" % time))
-            os.rename(rgbt, os.path.join(impath, "rgb%s.png" % time))
+            os.rename(os.path.join(impath, t), os.path.join(impath, "depth%s.tiff" % time[:-1]))
+            os.rename(rgbt, os.path.join(impath, "rgb%s.png" % time[:-1]))
             counter += 1
         timef.close()
 

--- a/openni_saver/src/cv_saver.cpp
+++ b/openni_saver/src/cv_saver.cpp
@@ -50,8 +50,7 @@ namespace cv_saver {
 	{
 	    int sec = msg->header.stamp.sec;
 	    int nsec = msg->header.stamp.nsec;
-	    std::cout << "Time lag = " << sec << "." << nsec << std::endl;
-	    std::cout << "Depths: " << depths.size() << " , RGBs: " << rgbs.size() << std::endl;
+	    ROS_INFO("Image timestamp: %d.%d, Stack: %ld:%ld", sec, nsec, depths.size(), rgbs.size());
 	    boost::shared_ptr<sensor_msgs::Image> tracked_object;
 		cv_bridge::CvImageConstPtr cv_img_boost_ptr;
 		try {
@@ -67,7 +66,6 @@ namespace cv_saver {
 	    char buffer[250];
 	    if (cv_img_boost_ptr->image.type() == CV_16UC1) {
             if (!rgbs.empty()) {
-                std::cout << "Received a depth image!" << std::endl;
                 delta = duration.total_milliseconds() - start;
 			    sprintf(buffer, "%s/depth%06d-%010d-%010d.png", impath.c_str(), delta, sec, nsec);
 			    std::vector<int> compression;
@@ -81,7 +79,6 @@ namespace cv_saver {
 		        rgb_nsecs.pop_front();
             }
             else {
-                std::cout << "Now i set depth!" << std::endl;
                 depths.push_back(cv_img_boost_ptr->image.clone());
                 depth_secs.push_back(sec);
                 depth_nsecs.push_back(nsec);
@@ -89,7 +86,6 @@ namespace cv_saver {
 		}
 		else if (cv_img_boost_ptr->image.type() == CV_8UC3) {
 		    if (!depths.empty()) {
-			    std::cout << "Received an RGB image!" << std::endl;
 			    delta = duration.total_milliseconds() - start;
 			    sprintf(buffer, "%s/rgb%06d-%010d-%010d.png", impath.c_str(), delta, sec, nsec);
 			    std::vector<int> compression;
@@ -103,7 +99,6 @@ namespace cv_saver {
 		        depth_nsecs.pop_front();
             }
             else {
-                std::cout << "Now i set rgb!" << std::endl;
                 rgbs.push_back(cv_img_boost_ptr->image.clone());
                 rgb_secs.push_back(sec);
                 rgb_nsecs.push_back(nsec);

--- a/openni_saver/src/cv_saver.cpp
+++ b/openni_saver/src/cv_saver.cpp
@@ -54,6 +54,7 @@ namespace cv_saver {
 	    boost::shared_ptr<sensor_msgs::Image> tracked_object;
 		cv_bridge::CvImageConstPtr cv_img_boost_ptr;
 		try {
+		    // here we can use toCvCopy instead, and don't have to do that later
 			cv_img_boost_ptr = cv_bridge::toCvShare(*msg, tracked_object);
 		}
 		catch (cv_bridge::Exception& e) {

--- a/strandsbag/CMakeLists.txt
+++ b/strandsbag/CMakeLists.txt
@@ -1,0 +1,129 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(strandsbag)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED)
+
+## System dependencies are found with CMake's conventions
+# find_package(Boost REQUIRED COMPONENTS system)
+
+
+## Uncomment this if the package has a setup.py. This macro ensures
+## modules and global scripts declared therein get installed
+## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
+# catkin_python_setup()
+
+#######################################
+## Declare ROS messages and services ##
+#######################################
+
+## Generate messages in the 'msg' folder
+# add_message_files(
+#   FILES
+#   Message1.msg
+#   Message2.msg
+# )
+
+## Generate services in the 'srv' folder
+# add_service_files(
+#   FILES
+#   Service1.srv
+#   Service2.srv
+# )
+
+## Generate added messages and services with any dependencies listed here
+# generate_messages(
+#   DEPENDENCIES
+#   std_msgs  # Or other packages containing msgs
+# )
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if you package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+#  INCLUDE_DIRS include
+#  LIBRARIES strandsbag
+#  CATKIN_DEPENDS other_catkin_pkg
+#  DEPENDS system_lib
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+# include_directories(include)
+
+## Declare a cpp library
+# add_library(strandsbag
+#   src/${PROJECT_NAME}/strandsbag.cpp
+# )
+
+## Declare a cpp executable
+# add_executable(strandsbag_node src/strandsbag_node.cpp)
+
+## Add cmake target dependencies of the executable/library
+## as an example, message headers may need to be generated before nodes
+# add_dependencies(strandsbag_node strandsbag_generate_messages_cpp)
+
+## Specify libraries to link a library or executable target against
+# target_link_libraries(strandsbag_node
+#   ${catkin_LIBRARIES}
+# )
+
+#############
+## Install ##
+#############
+
+# all install targets should use catkin DESTINATION variables
+# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
+
+## Mark executable scripts (Python etc.) for installation
+## in contrast to setup.py, you can choose the destination
+# install(PROGRAMS
+#   scripts/my_python_script
+#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark executables and/or libraries for installation
+# install(TARGETS strandsbag strandsbag_node
+#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+# )
+
+## Mark cpp header files for installation
+# install(DIRECTORY include/${PROJECT_NAME}/
+#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+#   FILES_MATCHING PATTERN "*.h"
+#   PATTERN ".svn" EXCLUDE
+# )
+
+## Mark other files for installation (e.g. launch and bag files, etc.)
+# install(FILES
+#   # myfile1
+#   # myfile2
+#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+# )
+
+#############
+## Testing ##
+#############
+
+## Add gtest based cpp test target and link libraries
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_strandsbag.cpp)
+# if(TARGET ${PROJECT_NAME}-test)
+#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
+# endif()
+
+## Add folders to be run by python nosetests
+# catkin_add_nosetests(test)

--- a/strandsbag/CMakeLists.txt
+++ b/strandsbag/CMakeLists.txt
@@ -4,11 +4,11 @@ project(strandsbag)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED)
+find_package(catkin REQUIRED COMPONENTS roscpp cv_bridge)
 
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
-
+find_package(OpenCV REQUIRED)
 
 ## Uncomment this if the package has a setup.py. This macro ensures
 ## modules and global scripts declared therein get installed
@@ -61,7 +61,9 @@ catkin_package(
 
 ## Specify additional locations of header files
 ## Your package locations should be listed before other locations
-# include_directories(include)
+include_directories(include
+  ${catkin_INCLUDE_DIRS}
+)
 
 ## Declare a cpp library
 # add_library(strandsbag
@@ -69,16 +71,16 @@ catkin_package(
 # )
 
 ## Declare a cpp executable
-# add_executable(strandsbag_node src/strandsbag_node.cpp)
+add_executable(play_images src/play_images.cpp)
 
 ## Add cmake target dependencies of the executable/library
 ## as an example, message headers may need to be generated before nodes
 # add_dependencies(strandsbag_node strandsbag_generate_messages_cpp)
 
 ## Specify libraries to link a library or executable target against
-# target_link_libraries(strandsbag_node
-#   ${catkin_LIBRARIES}
-# )
+target_link_libraries(play_images
+  ${catkin_LIBRARIES}
+)
 
 #############
 ## Install ##

--- a/strandsbag/package.xml
+++ b/strandsbag/package.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<package>
+  <name>strandsbag</name>
+  <version>0.0.0</version>
+  <description>The strandsbag package</description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
+  <!-- Example:  -->
+  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <maintainer email="nbore@todo.todo">nbore</maintainer>
+
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>TODO</license>
+
+
+  <!-- Url tags are optional, but mutiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://ros.org/wiki/strandsbag</url> -->
+
+
+  <!-- Author tags are optional, mutiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintianers, but could be -->
+  <!-- Example: -->
+  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+
+
+  <!-- The *_depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <!-- Examples: -->
+  <!-- Use build_depend for packages you need at compile time: -->
+  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use buildtool_depend for build tool packages: -->
+  <!--   <buildtool_depend>catkin</buildtool_depend> -->
+  <!-- Use run_depend for packages you need at runtime: -->
+  <!--   <run_depend>message_runtime</run_depend> -->
+  <!-- Use test_depend for packages you need only for testing: -->
+  <!--   <test_depend>gtest</test_depend> -->
+  <buildtool_depend>catkin</buildtool_depend>
+
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- You can specify that this package is a metapackage here: -->
+    <!-- <metapackage/> -->
+
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>

--- a/strandsbag/package.xml
+++ b/strandsbag/package.xml
@@ -40,6 +40,14 @@
   <!-- Use test_depend for packages you need only for testing: -->
   <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>cv_bridge</build_depend>
+  <build_depend>OpenCV</build_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>sensor_msgs</run_depend>
+  <run_depend>cv_bridge</run_depend>
+  <run_depend>OpenCV</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/strandsbag/src/play_images.cpp
+++ b/strandsbag/src/play_images.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main(int argc, char** argv)
+{
+    return 0;
+}

--- a/strandsbag/src/play_images.cpp
+++ b/strandsbag/src/play_images.cpp
@@ -1,6 +1,129 @@
+#include <ros/ros.h>
+#include <ros/time.h>
 #include <iostream>
+#include <cv_bridge/cv_bridge.h>
+#include <opencv2/opencv.hpp>
+#include <sensor_msgs/Image.h>
+//#include <std_msgs/Header.h>
+#include <vector>
+#include <string>
+#include <dirent.h>
+#include <stdio.h>
+
+void update_files(const std::string& dirname, std::vector<std::string>& depth_files, std::vector<std::string>& rgb_files)
+{
+    depth_files.clear();
+    rgb_files.clear();
+    std::string depth_name("depth");
+    std::string rgb_name("rgb");
+    DIR* dir = opendir(dirname.c_str());
+    if (dir == NULL) {
+        ROS_ERROR("Can not read video directory.");
+    }
+    struct dirent* ent;
+    while ((ent = readdir(dir)) != NULL) {
+        std::string entry(ent->d_name);
+        if (entry.compare(0, depth_name.size(), depth_name) == 0) {
+	        depth_files.push_back(entry);
+	    }
+	    else if (entry.compare(0, rgb_name.size(), rgb_name) == 0) {
+	        rgb_files.push_back(entry);
+	    }
+	    else {
+	        continue;
+	    }
+    }
+    closedir(dir);
+    std::sort(depth_files.begin(), depth_files.end());
+    std::reverse(depth_files.begin(), depth_files.end());
+    std::sort(rgb_files.begin(), rgb_files.end());
+    std::reverse(rgb_files.begin(), rgb_files.end());
+}
+
+void read_images(cv_bridge::CvImage& image_depth, cv_bridge::CvImage& image_rgb, cv::Mat& temp_depth, cv::Mat& temp_rgb, const std::string& dirname, const std::string& depth_file, const std::string& rgb_file)
+{
+    std::string depth_path = dirname + "/" + depth_file;
+    std::string rgb_path = dirname + "/" + rgb_file;
+    temp_depth = cv::imread(depth_path, -1);
+    temp_rgb = cv::imread(rgb_path, -1);
+    
+    std_msgs::Header header_depth;
+    std_msgs::Header header_rgb;
+    header_depth.stamp = ros::Time().now();
+    header_rgb.stamp = header_depth.stamp;
+    header_depth.frame_id = "/camera_depth_frame";
+    header_rgb.frame_id = "/camera_rgb_frame";
+    
+    image_depth = cv_bridge::CvImage(header_depth, "CV16UC1", temp_depth);
+    image_rgb = cv_bridge::CvImage(header_rgb, "CV8UC1", temp_rgb);
+    
+    if (remove(depth_path.c_str()) != 0) {
+        ROS_ERROR("Error deleting depth file.");
+    }
+    if (remove(rgb_path.c_str()) != 0) {
+        ROS_ERROR("Error deleting rgb file.");
+    }
+}
 
 int main(int argc, char** argv)
 {
-    return 0;
+    ros::init(argc, argv, "play_images");
+	ros::NodeHandle n;
+    if (!n.hasParam("/depth_saver_node/video_folder")) {
+        ROS_ERROR("Could not find parameter video_folder.");
+        return -1;
+    }
+    std::string video_folder;
+    n.getParam("/depth_saver_node/video_folder", video_folder);
+	ros::Publisher depth_pub = n.advertise<sensor_msgs::Image>("/camera/depth", 1000);
+	ros::Publisher rgb_pub = n.advertise<sensor_msgs::Image>("/camera/rgb", 1000);
+	
+	ros::Rate loop_rate(30);
+
+    /**
+    * A count of how many messages we have sent. This is used to create
+    * a unique string for each message.
+    */
+    int count = 0;
+    std::vector<std::string> depth_files;
+    std::vector<std::string> rgb_files;
+    update_files(video_folder, depth_files, rgb_files);
+    cv::Mat temp_depth(480, 640, CV_16UC1);
+    cv::Mat temp_rgb(480, 640, CV_8UC3);
+    cv_bridge::CvImage image_depth;
+    cv_bridge::CvImage image_rgb;
+    read_images(image_depth, image_rgb, temp_depth, temp_rgb, video_folder, depth_files.back(), rgb_files.back());
+    depth_files.pop_back();
+    rgb_files.pop_back();
+    
+    while (ros::ok())
+    {
+
+        /**
+         * The publish() function is how you send messages. The parameter
+         * is the message object. The type of this object must agree with the type
+         * given as a template parameter to the advertise<>() call, as was done
+         * in the constructor above.
+         */
+        depth_pub.publish(image_depth.toImageMsg());
+        rgb_pub.publish(image_rgb.toImageMsg());
+
+        ros::spinOnce();
+        
+        if (depth_files.size() < 60 || rgb_files.size() < 60) {
+            update_files(video_folder, depth_files, rgb_files);
+            if (depth_files.empty() || rgb_files.empty()) {
+                ROS_INFO("There are no more images to show, stopping.");
+                break;
+            }
+        }
+        
+        read_images(image_depth, image_rgb, temp_depth, temp_rgb, video_folder, depth_files.front(), rgb_files.front());
+
+        loop_rate.sleep();
+        ++count;
+    }
+
+	
+	return 0;
 }


### PR DESCRIPTION
This add the strandsbag package that will have launch files for creating a rosbag together with compressed videos and then playing them back later as though they were image topics. The code right now is only for pulling for the last images and publishing them, this will have to be done based on their timestamps. We will also need a python thread that decomposes the videos as they are needed. This will probably be done in a totally separate node since the play_images already looks for the latest image file to publish. The request also incorporates and important bugfix for the naming of the recreated images.
