### PR TITLE
Made the strandsbag play.launch and record.launch, which are supposed to be used as rosbag

### DIFF
--- a/libav_compressor/scripts/batch_decompressor.py
+++ b/libav_compressor/scripts/batch_decompressor.py
@@ -25,8 +25,9 @@ def batch_decompressor(impath):
         for t in templist:
             time = timef.readline()
             rgbt = os.path.join(impath, "temprgb" + t[-11:-5] + ".png")
-            os.rename(os.path.join(impath, t), os.path.join(impath, "depth%s.tiff" % time[:-1]))
-            os.rename(rgbt, os.path.join(impath, "rgb%s.png" % time[:-1]))
+            os.rename(os.path.join(impath, t), os.path.join(impath, "%s.tiff" % time[:-1]))
+            time = timef.readline()
+            os.rename(rgbt, os.path.join(impath, "%s.png" % time[:-1]))
             counter += 1
         timef.close()
 

--- a/openni_saver/src/cv_saver.cpp
+++ b/openni_saver/src/cv_saver.cpp
@@ -68,13 +68,13 @@ namespace cv_saver {
 	    if (cv_img_boost_ptr->image.type() == CV_16UC1) {
             if (!rgbs.empty()) {
                 delta = duration.total_milliseconds() - start;
-			    sprintf(buffer, "%s/depth%06d-%010d-%010d.png", impath.c_str(), delta, sec, nsec);
-			    std::vector<int> compression;
+                std::vector<int> compression;
                 compression.push_back(CV_IMWRITE_PNG_COMPRESSION);
                 compression.push_back(0);
-		        cv::imwrite(buffer, cv_img_boost_ptr->image, compression);
-		        sprintf(buffer, "%s/rgb%06d-%010d-%010d.png", impath.c_str(), delta, rgb_secs.front(), rgb_nsecs.front());
+                sprintf(buffer, "%s/rgb%06d-%010d-%010d.png", impath.c_str(), delta, rgb_secs.front(), rgb_nsecs.front());
 		        cv::imwrite(buffer, rgbs.front(), compression);
+			    sprintf(buffer, "%s/depth%06d-%010d-%010d.png", impath.c_str(), delta, sec, nsec);
+		        cv::imwrite(buffer, cv_img_boost_ptr->image, compression);
 		        rgbs.pop_front();
 		        rgb_secs.pop_front();
 		        rgb_nsecs.pop_front();
@@ -88,10 +88,10 @@ namespace cv_saver {
 		else if (cv_img_boost_ptr->image.type() == CV_8UC3) {
 		    if (!depths.empty()) {
 			    delta = duration.total_milliseconds() - start;
-			    sprintf(buffer, "%s/rgb%06d-%010d-%010d.png", impath.c_str(), delta, sec, nsec);
 			    std::vector<int> compression;
                 compression.push_back(CV_IMWRITE_PNG_COMPRESSION);
                 compression.push_back(0);
+			    sprintf(buffer, "%s/rgb%06d-%010d-%010d.png", impath.c_str(), delta, sec, nsec);
 		        cv::imwrite(buffer, cv_img_boost_ptr->image, compression);
 		        sprintf(buffer, "%s/depth%06d-%010d-%010d.png", impath.c_str(), delta, depth_secs.front(), depth_nsecs.front());
 		        cv::imwrite(buffer, depths.front(), compression);

--- a/strandsbag/CMakeLists.txt
+++ b/strandsbag/CMakeLists.txt
@@ -66,18 +66,25 @@ include_directories(include
 )
 
 ## Declare a cpp library
-# add_library(strandsbag
-#   src/${PROJECT_NAME}/strandsbag.cpp
-# )
+add_library(bag_player src/bag_player.cpp)
 
 ## Declare a cpp executable
 add_executable(play_images src/play_images.cpp)
+add_executable(image_player src/image_player.cpp)
 
 ## Add cmake target dependencies of the executable/library
 ## as an example, message headers may need to be generated before nodes
 # add_dependencies(strandsbag_node strandsbag_generate_messages_cpp)
 
 ## Specify libraries to link a library or executable target against
+target_link_libraries(bag_player
+  ${catkin_LIBRARIES}
+)
+
+target_link_libraries(image_player
+  bag_player ${catkin_LIBRARIES}
+)
+
 target_link_libraries(play_images
   ${catkin_LIBRARIES}
 )

--- a/strandsbag/launch/play.launch
+++ b/strandsbag/launch/play.launch
@@ -1,5 +1,6 @@
 <launch>
-    <node pkg="rosbag" type="play" name="player" output="screen" args="--clock $(find strandsbag)/bags/bagfile.bag"/>
+    <arg name="f"/>
+    <node pkg="rosbag" type="play" name="player" output="screen" args="--clock $(arg f)"/>
 	<node pkg="strandsbag" type="image_player" name="image_player" args="$(find libav_compressor)/images" output="screen">
 	    <param name="image_folder" value="$(find libav_compressor)/images"/>
     </node>

--- a/strandsbag/launch/play.launch
+++ b/strandsbag/launch/play.launch
@@ -1,6 +1,9 @@
 <launch>
+    <rosparam>
+        use_sim_time : true
+    </rosparam>
     <arg name="f"/>
-    <node pkg="rosbag" type="play" name="player" output="screen" args="--clock $(arg f)"/>
+    <node pkg="rosbag" type="play" name="player" output="screen" args="$(arg f) --clock"/>
 	<node pkg="strandsbag" type="image_player" name="image_player" args="$(find libav_compressor)/images" output="screen">
 	    <param name="image_folder" value="$(find libav_compressor)/images"/>
     </node>

--- a/strandsbag/launch/play.launch
+++ b/strandsbag/launch/play.launch
@@ -1,0 +1,7 @@
+<launch>
+    <node pkg="rosbag" type="play" name="player" output="screen" args="--clock $(find strandsbag)/bags/bagfile.bag"/>
+	<node pkg="strandsbag" type="image_player" name="image_player" args="$(find libav_compressor)/images" output="screen">
+	    <param name="image_folder" value="$(find libav_compressor)/images"/>
+    </node>
+e>
+</launch>

--- a/strandsbag/launch/record.launch
+++ b/strandsbag/launch/record.launch
@@ -1,0 +1,6 @@
+<launch>
+    <arg name="f" default=""/>
+    <node pkg="rosbag" type="record" name="recorder" output="screen" args="/rosout /rosout_agg -o $(arg f)"/>
+	<include file="$(find libav_compressor)/launch/video_saver.launch"/>
+e>
+</launch>

--- a/strandsbag/package.xml
+++ b/strandsbag/package.xml
@@ -44,10 +44,13 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>cv_bridge</build_depend>
   <build_depend>OpenCV</build_depend>
+  <build_depend>rosgraph_msgs</build_depend>
+  
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>cv_bridge</run_depend>
   <run_depend>OpenCV</run_depend>
+  <run_depend>rosgraph_msgs</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/strandsbag/src/bag_player.cpp
+++ b/strandsbag/src/bag_player.cpp
@@ -1,0 +1,115 @@
+#include "bag_player.h"
+
+#include <sensor_msgs/Image.h>
+#include <dirent.h>
+#include <iostream>
+#include <string>
+
+bag_player::bag_player(ros::NodeHandle& n, ros::Publisher& depth_pub, ros::Publisher& rgb_pub, const std::string& dirname) : n(n), depth_pub(depth_pub), rgb_pub(rgb_pub), dirname(dirname), temp_depth(480, 640, CV_16UC1), temp_rgb(480, 640, CV_8UC3)
+{
+    update_files();
+    ros::Time t = read_depth();
+    depth_timer = n.createTimer(t - ros::Time::now(), &bag_player::publish_depth, this, true);
+    t = read_rgb();
+    rgb_timer = n.createTimer(t - ros::Time::now(), &bag_player::publish_rgb, this, true);
+}
+
+void bag_player::update_files()
+{
+    depth_files.clear();
+    rgb_files.clear();
+    std::string depth_name("depth");
+    std::string rgb_name("rgb");
+    DIR* dir = opendir(dirname.c_str());
+    if (dir == NULL) {
+        ROS_ERROR("Can not read video directory.");
+    }
+    struct dirent* ent;
+    while ((ent = readdir(dir)) != NULL) {
+        std::string entry(ent->d_name);
+        if (entry.compare(0, depth_name.size(), depth_name) == 0) {
+	        depth_files.push_back(entry);
+	    }
+	    else if (entry.compare(0, rgb_name.size(), rgb_name) == 0) {
+	        rgb_files.push_back(entry);
+	    }
+	    else {
+	        continue;
+	    }
+    }
+    closedir(dir);
+    std::sort(depth_files.begin(), depth_files.end());
+    std::reverse(depth_files.begin(), depth_files.end());
+    std::sort(rgb_files.begin(), rgb_files.end());
+    std::reverse(rgb_files.begin(), rgb_files.end());
+}
+
+ros::Time bag_player::read_depth()
+{
+    std::string depth_file = depth_files.back();
+    depth_files.pop_back();
+    std::string depth_path = dirname + "/" + depth_file;
+    temp_depth = cv::imread(depth_path, -1);
+    
+    std::string depth_sec = depth_file.substr(12, 10);
+    std::string depth_nsec = depth_file.substr(23, 10);
+    
+    std_msgs::Header header_depth;
+    header_depth.stamp = ros::Time(atoi(depth_sec.c_str()), atoi(depth_nsec.c_str()));
+    
+    std::cout << "Depth time: " << header_depth.stamp << std::endl;
+    
+    header_depth.frame_id = "/camera_depth_frame"; // should probably be a parameter
+    
+    image_depth = cv_bridge::CvImage(header_depth, "16UC1", temp_depth);
+    
+    /*if (remove(depth_path.c_str()) != 0) {
+        ROS_ERROR("Error deleting depth file.");
+    }*/
+    return header_depth.stamp;
+}
+
+ros::Time bag_player::read_rgb()
+{
+    std::string rgb_file = rgb_files.back();
+    rgb_files.pop_back();
+    std::string rgb_path = dirname + "/" + rgb_file;
+    temp_rgb = cv::imread(rgb_path, -1);
+    
+    std::string rgb_sec = rgb_file.substr(10, 10);
+    std::string rgb_nsec = rgb_file.substr(21, 10);
+    
+    std_msgs::Header header_rgb;
+    header_rgb.stamp = ros::Time(atoi(rgb_sec.c_str()), atoi(rgb_nsec.c_str()));
+    
+    std::cout << "RGB time: " << header_rgb.stamp << std::endl;
+    
+    header_rgb.frame_id = "/camera_rgb_frame"; // should probably be a parameter
+    
+    image_rgb = cv_bridge::CvImage(header_rgb, "8UC3", temp_rgb);
+    
+    /*if (remove(rgb_path.c_str()) != 0) {
+        ROS_ERROR("Error deleting rgb file.");
+    }*/
+    return header_rgb.stamp;
+}
+
+void bag_player::publish_depth(const ros::TimerEvent& e)
+{
+    depth_pub.publish(image_depth.toImageMsg());
+    if (depth_files.size() == 0) {
+        return;
+    }
+    ros::Time t = read_depth();
+    depth_timer = n.createTimer(t - ros::Time::now(), &bag_player::publish_depth, this, true);
+}
+
+void bag_player::publish_rgb(const ros::TimerEvent& e)
+{
+    rgb_pub.publish(image_rgb.toImageMsg());
+    if (rgb_files.size() == 0) {
+        return;
+    }
+    ros::Time t = read_rgb();
+    rgb_timer = n.createTimer(t - ros::Time::now(), &bag_player::publish_rgb, this, true);
+}

--- a/strandsbag/src/bag_player.cpp
+++ b/strandsbag/src/bag_player.cpp
@@ -57,6 +57,7 @@ ros::Time bag_player::read_depth()
     std_msgs::Header header_depth;
     header_depth.stamp = ros::Time(atoi(depth_sec.c_str()), atoi(depth_nsec.c_str()));
     
+    std::cout << "ROS time: " << ros::Time::now() << std::endl;
     std::cout << "Depth time: " << header_depth.stamp << std::endl;
     
     header_depth.frame_id = "/camera_depth_frame"; // should probably be a parameter

--- a/strandsbag/src/bag_player.h
+++ b/strandsbag/src/bag_player.h
@@ -1,0 +1,34 @@
+#ifndef BAG_PLAYER_H
+#define BAG_PLAYER_H
+
+#include <ros/ros.h>
+#include <ros/time.h>
+#include <cv_bridge/cv_bridge.h>
+#include <opencv2/opencv.hpp>
+#include <vector>
+
+class bag_player {
+private:
+    ros::NodeHandle& n;
+    ros::Publisher& depth_pub;
+    ros::Publisher& rgb_pub;
+    std::string dirname;
+    std::vector<std::string> depth_files;
+    std::vector<std::string> rgb_files;
+    cv::Mat temp_depth;
+    cv::Mat temp_rgb;
+    cv_bridge::CvImage image_depth;
+    cv_bridge::CvImage image_rgb;
+    ros::Timer depth_timer;
+    ros::Timer rgb_timer;
+    
+    ros::Time read_depth();
+    ros::Time read_rgb();
+    void update_files();
+public:
+    void publish_depth(const ros::TimerEvent& e);
+    void publish_rgb(const ros::TimerEvent& e);
+    bag_player(ros::NodeHandle& n, ros::Publisher& depth_pub, ros::Publisher& rgb_pub, const std::string& dirname);
+};
+
+#endif

--- a/strandsbag/src/bag_player.h
+++ b/strandsbag/src/bag_player.h
@@ -2,7 +2,8 @@
 #define BAG_PLAYER_H
 
 #include <ros/ros.h>
-#include <ros/time.h>
+//#include <ros/time.h>
+#include <rosgraph_msgs/Clock.h>
 #include <cv_bridge/cv_bridge.h>
 #include <opencv2/opencv.hpp>
 #include <vector>

--- a/strandsbag/src/image_player.cpp
+++ b/strandsbag/src/image_player.cpp
@@ -1,0 +1,23 @@
+#include <ros/ros.h>
+#include <ros/time.h>
+#include <iostream>
+#include "bag_player.h"
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "image_player");
+	ros::NodeHandle n;
+    if (!n.hasParam("/image_player/image_folder")) {
+        ROS_ERROR("Could not find parameter image_folder.");
+        return -1;
+    }
+    std::string image_folder;
+    n.getParam("/image_player/image_folder", image_folder);
+	ros::Publisher depth_pub = n.advertise<sensor_msgs::Image>("/bag_player/depth", 10);
+	ros::Publisher rgb_pub = n.advertise<sensor_msgs::Image>("/bag_player/rgb", 10);
+    
+    bag_player player(n, depth_pub, rgb_pub, image_folder);
+    ros::spin();
+	
+	return 0;
+}

--- a/strandsbag/src/image_player.cpp
+++ b/strandsbag/src/image_player.cpp
@@ -15,7 +15,7 @@ int main(int argc, char** argv)
     n.getParam("/image_player/image_folder", image_folder);
 	ros::Publisher depth_pub = n.advertise<sensor_msgs::Image>("/bag_player/depth", 10);
 	ros::Publisher rgb_pub = n.advertise<sensor_msgs::Image>("/bag_player/rgb", 10);
-    
+    ros::Duration(0.18f).sleep();
     bag_player player(n, depth_pub, rgb_pub, image_folder);
     ros::spin();
 	

--- a/strandsbag/src/play_images.cpp
+++ b/strandsbag/src/play_images.cpp
@@ -48,10 +48,21 @@ void read_images(cv_bridge::CvImage& image_depth, cv_bridge::CvImage& image_rgb,
     temp_depth = cv::imread(depth_path, -1);
     temp_rgb = cv::imread(rgb_path, -1);
     
+    //depth003896-1376404206-0409239781
+    std::string depth_sec = depth_file.substr(12, 10);
+    std::string depth_nsec = depth_file.substr(23, 10);
+    
+    std::string rgb_sec = rgb_file.substr(10, 10);
+    std::string rgb_nsec = rgb_file.substr(21, 10);
+    
     std_msgs::Header header_depth;
     std_msgs::Header header_rgb;
-    header_depth.stamp = ros::Time().now();
-    header_rgb.stamp = header_depth.stamp;
+    header_depth.stamp = ros::Time(atoi(depth_sec.c_str()), atoi(depth_nsec.c_str())); //ros::Time().now();
+    header_rgb.stamp = ros::Time(atoi(rgb_sec.c_str()), atoi(rgb_nsec.c_str())); //header_depth.stamp;
+    
+    std::cout << "Depth time: " << header_depth.stamp << std::endl;
+    std::cout << "RGB time: " << header_rgb.stamp << std::endl;
+    
     header_depth.frame_id = "/camera_depth_frame"; // should probably be a parameter
     header_rgb.frame_id = "/camera_rgb_frame"; // should probably be a parameter
     
@@ -91,7 +102,7 @@ int main(int argc, char** argv)
     n.getParam("/play_images/image_folder", image_folder);
 	ros::Publisher depth_pub = n.advertise<sensor_msgs::Image>("/player/depth", 10);
 	ros::Publisher rgb_pub = n.advertise<sensor_msgs::Image>("/player/rgb", 10);
-	ros::Subscriber time_sub = n.subscribe("/clock", 1, &time_callback);
+	//ros::Subscriber time_sub = n.subscribe("/clock", 1, &time_callback);
 	//n.subscribe("camera/depth/image_raw", 2, &cv_saver::image_callback);
 	
 	ros::Rate loop_rate(30);


### PR DESCRIPTION
This commit makes the use of the compression more convenient as it enables it to use with rosbag. You can now record a rosbag with roslaunch strandsbag record.launch f:=(FILE) and view it with roslaunch strandsbag play.launch f:=(FILE). The nodes make sure that the image streams are published at the same time that they were recorded originally by looking at the saved timestamps of the video frames/images and synch them with the rosbag simulated time.

At the moment you need to decompress the videos with roslaunch libavcompressor video_loader.launch before you can use play.launch. This is to be automated so that decompression is automatically run as we need more recent frames and the old frames are deleted.

The api of strandsbag should also be made to more or less mirror that of rosbag.

Also, I will sit down tomorrow and try to comment as much of the code as possible, and do some documentation.
