### PR TITLE
Changed to use right topic names and to record all topics except the camera streams in rosbag

### DIFF
--- a/libav_compressor/launch/video_loader.launch
+++ b/libav_compressor/launch/video_loader.launch
@@ -1,5 +1,8 @@
 <launch>
+    <!-- Directory to load the videos -->
+    <arg name="video_path" default="$(find libav_compressor)/videos"/>
+    
     <!-- Decompress the videos recorded with video_saver or strandsbag record -->
-	<node pkg="libav_compressor" type="batch_decompressor.py" name="batch_decompressor" args="$(find libav_compressor)/images" output="screen"/>
+	<node pkg="libav_compressor" type="batch_decompressor.py" name="batch_decompressor" args="$(find libav_compressor)/images $(arg video_path)" output="screen"/>
 e>
 </launch>

--- a/libav_compressor/launch/video_saver.launch
+++ b/libav_compressor/launch/video_saver.launch
@@ -1,9 +1,15 @@
 <launch>
+    <!-- Directory to store the videos -->
+    <arg name="video_path" default="$(find libav_compressor)/videos"/>
+
     <!-- Save images from openni_launch topics to video, online into smaller videos -->
     <!-- Used by strandsbag record -->
+    <!-- Launch saving of depth images -->
     <node pkg="openni_saver" type="synch_saver_node" name="synch_saver_node" output="screen">
         <param name="image_folder" value="$(find openni_saver)/images"/>
+        <param name="camera_topic" value="head_xtion"/>
     </node>
-	<node pkg="libav_compressor" type="batch_compressor.py" name="batch_compressor" args="$(find openni_saver)/images" output="screen"/>
+    <!-- Launch compressor -->
+	<node pkg="libav_compressor" type="batch_compressor.py" name="batch_compressor" args="$(find openni_saver)/images $(arg video_path)" output="screen"/>
 e>
 </launch>

--- a/libav_compressor/scripts/batch_decompressor.py
+++ b/libav_compressor/scripts/batch_decompressor.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python
 import sched, time, os, sys
 
-def batch_decompressor(impath):
+def batch_decompressor(impath, vidpath):
     print "Decompressing..."
-    # fixed path to the videos, should be parameter
-    vidpath = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, "videos"))
     flist = os.listdir(vidpath) # find all depth videos, order them
     flist = filter(lambda s: s[:5] == "depth", flist)
     flist.sort(key = lambda s: int(s[5:15]))
@@ -37,4 +35,7 @@ def batch_decompressor(impath):
         timef.close()
 
 if __name__ == "__main__":
-    batch_decompressor(sys.argv[1])
+    if len(sys.argv) < 3:
+        print "Not enough arguments to batch_decompressor.py"
+    else:
+        batch_decompressor(sys.argv[1], sys.argv[2])

--- a/openni_saver/src/synch_saver_node.cpp
+++ b/openni_saver/src/synch_saver_node.cpp
@@ -12,10 +12,16 @@ int main(int argc, char** argv)
     }
     std::string image_folder;
     n.getParam("/synch_saver_node/image_folder", image_folder);
+    if (!n.hasParam("/synch_saver_node/camera_topic")) {
+        std::cout << "You have to provide the camera_topic parameter!" << std::endl;
+        return -1;
+    }
+    std::string camera_topic;
+    n.getParam("/synch_saver_node/camera_topic", camera_topic);
     cv_saver::init_saver(image_folder);
-    //ros::Duration(0.5).sleep();
-	ros::Subscriber depthSub = n.subscribe("camera/depth/image_raw", 10, &cv_saver::synch_callback);
-    ros::Subscriber rgbSub = n.subscribe("camera/rgb/image_color", 10, &cv_saver::synch_callback);
+    std::cout << camera_topic + "/depth/image_raw" << std::endl;
+	ros::Subscriber depthSub = n.subscribe(camera_topic + "/depth/image_raw", 10, &cv_saver::synch_callback);
+    ros::Subscriber rgbSub = n.subscribe(camera_topic + "/rgb/image_color", 10, &cv_saver::synch_callback);
 	ros::spin();
 
 	return 0;

--- a/strandsbag/launch/decompress.launch
+++ b/strandsbag/launch/decompress.launch
@@ -1,0 +1,11 @@
+<launch>
+
+    <!-- Directory to load the videos -->
+    <arg name="video_path" default="$(find libav_compressor)/videos"/>
+    
+    <!-- This launch file already handles the decompression -->
+    <include file="$(find libav_compressor)/launch/video_loader.launch">
+        <arg name="video_path" value="$(arg video_path)"/>
+    </include>
+    
+</launch>

--- a/strandsbag/launch/play.launch
+++ b/strandsbag/launch/play.launch
@@ -3,10 +3,38 @@
     <rosparam>
         use_sim_time : true
     </rosparam>
+    
     <!-- The file name of the rosbag to play -->
-    <arg name="f"/>
+    <arg name="o"/>
+    
+    <!-- Option to suppress output -->
+    <arg name="q" default="false"/>
+    <arg name="quiet" value="-q" if="$(arg q)"/>
+    <arg name="quiet" value="" unless="$(arg q)"/>
+    
+    <!-- Option to play without waiting, not sure if works with videos -->
+    <arg name="i" default="false"/>
+    <arg name="immediate" value="-i" if="$(arg i)"/>
+    <arg name="immediate" value="" unless="$(arg i)"/>
+    
+    <!-- Option to loop the play, this does not work with videos -->
+    <arg name="l" default="false"/>
+    <arg name="loop" value="-l" if="$(arg l)"/>
+    <arg name="loop" value="" unless="$(arg l)"/>
+    
+    <!-- Option to keep the bag running after it is empty -->
+    <arg name="k" default="false"/>
+    <arg name="keepalive" value="-k" if="$(arg k)"/>
+    <arg name="keepalive" value="" unless="$(arg k)"/>
+    
+    <!-- Start the bag paused, should work with videos -->
+    <arg name="pause" default="false"/>
+    <arg name="dopause" value="--pause" if="$(arg pause)"/>
+    <arg name="dopause" value="" unless="$(arg pause)"/>
+    
     <!-- Launch the rosbag -->
-    <node pkg="rosbag" type="play" name="player" output="screen" args="$(arg f) --clock"/>
+    <node pkg="rosbag" type="play" name="player" output="screen" args="$(arg o) --clock $(arg dopause) $(arg keepalive) $(arg loop) $(arg quiet) $(arg immediate)"/>
+    
     <!-- Launch the node streaming the images from a folder -->
 	<node pkg="strandsbag" type="image_player" name="image_player" args="$(find libav_compressor)/images" output="screen">
 	    <param name="image_folder" value="$(find libav_compressor)/images"/>

--- a/strandsbag/launch/play.launch
+++ b/strandsbag/launch/play.launch
@@ -38,6 +38,7 @@
     <!-- Launch the node streaming the images from a folder -->
 	<node pkg="strandsbag" type="image_player" name="image_player" args="$(find libav_compressor)/images" output="screen">
 	    <param name="image_folder" value="$(find libav_compressor)/images"/>
+	    <param name="camera_topic" value="head_xtion"/>
     </node>
 e>
 </launch>

--- a/strandsbag/launch/record.launch
+++ b/strandsbag/launch/record.launch
@@ -1,8 +1,20 @@
 <launch>
     <!-- The name of the rosbag to be saved -->
-    <arg name="f" default=""/>
+    <arg name="o"/>
+    
+    <!-- Option to suppress output -->
+    <arg name="q" default="false"/>
+    <arg name="quiet" value="-q" if="$(arg q)"/>
+    <arg name="quiet" value="" unless="$(arg q)"/>
+    
+    <!-- Option to use bz2 compression -->
+    <arg name="j" default="false"/>
+    <arg name="bz2" value="-j" if="$(arg j)"/>
+    <arg name="bz2" value="" unless="$(arg j)"/>
+    
     <!-- Record a rosbag, use regular expressions to exclude images -->
-    <node pkg="rosbag" type="record" name="recorder" output="screen" args="/rosout /rosout_agg -o $(arg f)"/>
+    <node pkg="rosbag" type="record" name="recorder" output="screen" args="-a -x "/head_xtion/(.*)" $(arg quiet) $(arg bz2) -o $(arg o)"/>
+    
     <!-- Save the images published by openni_launch -->
 	<include file="$(find libav_compressor)/launch/video_saver.launch"/>
 e>

--- a/strandsbag/launch/record.launch
+++ b/strandsbag/launch/record.launch
@@ -13,9 +13,13 @@
     <arg name="bz2" value="" unless="$(arg j)"/>
     
     <!-- Record a rosbag, use regular expressions to exclude images -->
-    <node pkg="rosbag" type="record" name="recorder" output="screen" args="-a -x "/head_xtion/(.*)" $(arg quiet) $(arg bz2) -o $(arg o)"/>
+    <node pkg="rosbag" type="record" name="recorder" output="screen" args="-a -x &quot;/head_xtion/(.*)&quot; $(arg quiet) $(arg bz2) -o $(arg o)"/>
+    
+    <arg name="video_path" default="$(find libav_compressor)/videos"/>
     
     <!-- Save the images published by openni_launch -->
-	<include file="$(find libav_compressor)/launch/video_saver.launch"/>
+	<include file="$(find libav_compressor)/launch/video_saver.launch">
+	    <arg name="video_path" value="$(arg video_path)"/>
+	</include>
 e>
 </launch>

--- a/strandsbag/src/image_player.cpp
+++ b/strandsbag/src/image_player.cpp
@@ -13,8 +13,14 @@ int main(int argc, char** argv)
     }
     std::string image_folder;
     n.getParam("/image_player/image_folder", image_folder);
-	ros::Publisher depth_pub = n.advertise<sensor_msgs::Image>("/bag_player/depth", 10);
-	ros::Publisher rgb_pub = n.advertise<sensor_msgs::Image>("/bag_player/rgb", 10);
+    if (!n.hasParam("/image_player/camera_topic")) {
+        ROS_ERROR("Could not find parameter camera_topic.");
+        return -1;
+    }
+    std::string camera_topic;
+    n.getParam("/image_player/camera_topic", camera_topic);
+	ros::Publisher depth_pub = n.advertise<sensor_msgs::Image>(camera_topic + "/depth/image_raw", 10);
+	ros::Publisher rgb_pub = n.advertise<sensor_msgs::Image>(camera_topic + "/rgb/image_color", 10);
     ros::Duration(0.18f).sleep();
     // the magic happens in the bag_player
     bag_player player(n, depth_pub, rgb_pub, image_folder);


### PR DESCRIPTION
Changed to use right topic names and to record all topics except the camera streams in rosbag. Also mapped some parameters from strandsbag into rosbag. This commit should make it possible to use the strandsbag for real tasks. To use it do:
roslaunch strandsbag record.launch o:=(PATH_TO_BAG)/mybag.bag video_path:=(PATH_TO_VIDEO)
roslaunch strandsbag decompress.launch video_path:=(PATH_TO_VIDEO)
roslaunch strandsbag play o:=(PATH_TO_BAG)/mybag.bag
What remains is mainly to test it rigorously on the robot and add online decompression.
