### PR TITLE
Added scripts to remove files after playing the bag

### DIFF
--- a/strandsbag/launch/cleanup.launch
+++ b/strandsbag/launch/cleanup.launch
@@ -1,0 +1,9 @@
+<launch>
+    
+    <!-- Remove the last few files that werent compressed before cancelling -->
+    <node pkg="strandsbag" type="remove_files.py" name="remove_temporary" args="$(find openni_saver)/images" output="screen"/>
+    
+    <!-- Remove the decompressed files that are used by strandsbag play -->
+    <node pkg="strandsbag" type="remove_files.py" name="remove_decompressed" args="$(find libav_compressor)/images" output="screen"/>
+    
+</launch>

--- a/strandsbag/scripts/remove_files.py
+++ b/strandsbag/scripts/remove_files.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+import os, sys
+
+def remove_files(folder):
+    flist = os.listdir(folder)
+    for f in flist:
+        os.remove(os.path.join(folder, f))
+    
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print "Not enough arguments to remove_files.py"
+    else:
+        remove_files(sys.argv[1])


### PR DESCRIPTION
Straightforward, just use roslaunch strandsbag cleanup to remove decompressed images and temporary files from recording.
