### PR TITLE
Made some changes to make sure it works with long_term_patroller_with_logging

### DIFF
--- a/libav_compressor/scripts/batch_compressor.py
+++ b/libav_compressor/scripts/batch_compressor.py
@@ -10,7 +10,7 @@ def create_folder(path):
 
 def callback(sc, impath, vidpath, nbr):
     # schedule new callback in 20s
-    sc.enter(20, 1, callback, (sc, impath, vidpath, nbr+1))
+    sc.enter(6, 1, callback, (sc, impath, vidpath, nbr+1))
     print "Compressing..."
     temps = []
     first = ""
@@ -75,7 +75,7 @@ def batch_compressor(impath, vidpath):
     create_folder(vidpath) # create folder for resulting videos
     s = sched.scheduler(time.time, time.sleep)
     nbr = 0
-    s.enter(20, 1, callback, (s, impath, vidpath, nbr))
+    s.enter(6, 1, callback, (s, impath, vidpath, nbr))
     s.run()
 
 if __name__ == "__main__":

--- a/openni_saver/src/cv_saver.cpp
+++ b/openni_saver/src/cv_saver.cpp
@@ -15,7 +15,7 @@ namespace cv_saver {
 		boost::posix_time::ptime time = boost::posix_time::microsec_clock::local_time();
 		boost::posix_time::time_duration duration(time.time_of_day());
 		start = duration.total_milliseconds();
-		recording = true;
+		recording = false;//true;
 	}
 
     // for saving images from one stream


### PR DESCRIPTION
Made some changes to make sure it works with long_term_patroller_with_logging. One of them is temporary, the option to not start the video recording immediately should be optional both in the patroller launch file and in strandsbag.
