### PR TITLE
[catkinized_libav] Add install targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,12 @@ data_compression
 Video encoding for OpenNI topics to record them to a rosbag and replay through reconstruction of point clouds.
 
 Includes libav_image_transport by Dominique Hunziker: https://github.com/rapyuta/libav_image_transport.
+
+## Compiling
+
+Before doing `catkin_make` on the containing workspace, you need to fetch the submodules one time
+
+* `git submodule init`
+* `git submodule update`
+
+within the git repository.

--- a/catkinized_libav/CMakeLists.txt
+++ b/catkinized_libav/CMakeLists.txt
@@ -27,16 +27,38 @@ ExternalProject_Add(libav_trunk
 )
 
 add_library(libav_wrap src/wrap_lib.cc)
-SET(LIBAV_LIBRARY_DEST ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_LIB_DESTINATION})
-target_link_libraries(libav_wrap ${LIBAV_LIBRARY_DEST}/libavcodec.so ${LIBAV_LIBRARY_DEST}/libavdevice.so ${LIBAV_LIBRARY_DEST}/libavfilter.so ${LIBAV_LIBRARY_DEST}/libavformat.so ${LIBAV_LIBRARY_DEST}/libavresample.so ${LIBAV_LIBRARY_DEST}/libavutil.so ${LIBAV_LIBRARY_DEST}/libswscale.so)
+SET(LIBAV_LIBRARY_DEST ${CATKIN_DEVEL_PREFIX}/lib)
+SET(LIBAV_INCLUDE_DEST ${CATKIN_DEVEL_PREFIX}/include)
+
+SET(LIBAV_LIBS ${LIBAV_LIBRARY_DEST}/libavcodec.so
+  ${LIBAV_LIBRARY_DEST}/libavdevice.so ${LIBAV_LIBRARY_DEST}/libavfilter.so
+  ${LIBAV_LIBRARY_DEST}/libavformat.so ${LIBAV_LIBRARY_DEST}/libavresample.so
+  ${LIBAV_LIBRARY_DEST}/libavutil.so ${LIBAV_LIBRARY_DEST}/libswscale.so
+)
+
+SET(LIBAV_INCLUDE_DIRS ${LIBAV_INCLUDE_DEST}/libavcodec
+  ${LIBAV_INCLUDE_DEST}/libavdevice ${LIBAV_INCLUDE_DEST}/libavfilter
+  ${LIBAV_INCLUDE_DEST}/libavformat ${LIBAV_INCLUDE_DEST}/libavresample
+  ${LIBAV_INCLUDE_DEST}/libavutil ${LIBAV_INCLUDE_DEST}/libswscale
+)
+
+set (LIBS_DEREF "")
+foreach (_file ${LIBAV_LIBS})
+    get_filename_component(_resolvedFile "${_file}" REALPATH)
+    list (APPEND LIBS_DEREF "${_resolvedFile}")
+endforeach()
+
+target_link_libraries(libav_wrap ${LIBAV_LIBS})
 add_dependencies(libav_wrap libav_trunk)
- 
-install(DIRECTORY include
-DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}
+
+install(TARGETS libav_wrap
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
 )
-install(DIRECTORY lib
-DESTINATION ${CATKIN_GLOBAL_LIB_DESTINATION}
+
+install(DIRECTORY ${LIBAV_INCLUDE_DIRS}
+  DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}
 )
-install(DIRECTORY share
-DESTINATION ${CATKIN_GLOBAL_SHARE_DESTINATION}
+
+install(FILES ${LIBS_DEREF}
+  DESTINATION ${CATKIN_GLOBAL_LIB_DESTINATION}
 )

--- a/catkinized_libav/CMakeLists.txt
+++ b/catkinized_libav/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 2.8.3)
 project(catkinized_libav)
  
 set(CMAKE_BUILD_TYPE Release)
-#set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
  
 find_package(catkin REQUIRED)
  
@@ -32,12 +31,6 @@ set(LIBAV_COMPONENTS avcodec avdevice avfilter avformat avresample avutil swscal
 set (LIBAV_LIBS "")
 set (LIBAV_INCLUDE_DIRS "")
 foreach (_name ${LIBAV_COMPONENTS})
-    #find_library(_library_file
-    #  NAMES ${_name}
-    #  PATHS ${LIBAV_LIBRARY_DEST}
-    #  NO_DEFAULT_PATH
-    #)
-    #list (APPEND LIBAV_LIBS "${_library_file}")
     list (APPEND LIBAV_LIBS "${LIBAV_LIBRARY_DEST}/lib${_name}.so")
     list (APPEND LIBAV_INCLUDE_DIRS "${LIBAV_INCLUDE_DEST}/lib${_name}")
 endforeach()
@@ -53,11 +46,6 @@ install(TARGETS libav_wrap
 install(DIRECTORY ${LIBAV_INCLUDE_DIRS}
   DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}
 )
-
-#install(DIRECTORY ${LIBAV_LIBRARY_DEST}/.
-#  DESTINATION ${CATKIN_GLOBAL_LIB_DESTINATION}
-#  EXPORT_LINK_INTERFACE_LIBRARIES
-#)
 
 foreach (_name ${LIBAV_COMPONENTS})
   install(DIRECTORY ${LIBAV_LIBRARY_DEST}/.

--- a/catkinized_libav/CMakeLists.txt
+++ b/catkinized_libav/CMakeLists.txt
@@ -19,7 +19,7 @@ LIBRARIES libav_wrap
 ExternalProject_Add(libav_trunk
   DOWNLOAD_COMMAND ""
   SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/libav_trunk"
-  CONFIGURE_COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/libav_trunk/configure" --enable-shared --enable-libx264 --enable-gpl --prefix="${CATKIN_DEVEL_PREFIX}"
+  CONFIGURE_COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/libav_trunk/configure" --enable-shared --enable-gpl --prefix="${CATKIN_DEVEL_PREFIX}"#--enable-libx264 
 )
 
 add_library(libav_wrap src/wrap_lib.cc)

--- a/catkinized_libav/CMakeLists.txt
+++ b/catkinized_libav/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(catkinized_libav)
  
 set(CMAKE_BUILD_TYPE Release)
+#set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
  
 find_package(catkin REQUIRED)
  
@@ -12,44 +13,38 @@ set(VERSION 2.4.1)
 catkin_package(
 #DEPENDS
 #CATKIN_DEPENDS
-#INCLUDE_DIRS include
+#INCLUDE_DIRS include # libav is already in /devel/include
 LIBRARIES libav_wrap
 )
 
 ExternalProject_Add(libav_trunk
-#  PREFIX libav_trunk
-#  GIT_REPOSITORY https://github.com/libav/libav.git
-#  GIT_TAG v9.8
-#  DOWNLOAD_DIR "${CMAKE_CURRENT_SOURCE_DIR}/libav_trunk"
   DOWNLOAD_COMMAND ""
   SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/libav_trunk"
   CONFIGURE_COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/libav_trunk/configure" --enable-shared --enable-libx264 --enable-gpl --prefix="${CATKIN_DEVEL_PREFIX}"
 )
 
 add_library(libav_wrap src/wrap_lib.cc)
-SET(LIBAV_LIBRARY_DEST ${CATKIN_DEVEL_PREFIX}/lib)
-SET(LIBAV_INCLUDE_DEST ${CATKIN_DEVEL_PREFIX}/include)
+set(LIBAV_LIBRARY_DEST ${CATKIN_DEVEL_PREFIX}/lib)
+set(LIBAV_INCLUDE_DEST ${CATKIN_DEVEL_PREFIX}/include)
 
-SET(LIBAV_LIBS ${LIBAV_LIBRARY_DEST}/libavcodec.so
-  ${LIBAV_LIBRARY_DEST}/libavdevice.so ${LIBAV_LIBRARY_DEST}/libavfilter.so
-  ${LIBAV_LIBRARY_DEST}/libavformat.so ${LIBAV_LIBRARY_DEST}/libavresample.so
-  ${LIBAV_LIBRARY_DEST}/libavutil.so ${LIBAV_LIBRARY_DEST}/libswscale.so
-)
+set(LIBAV_COMPONENTS avcodec avdevice avfilter avformat avresample avutil swscale)
 
-SET(LIBAV_INCLUDE_DIRS ${LIBAV_INCLUDE_DEST}/libavcodec
-  ${LIBAV_INCLUDE_DEST}/libavdevice ${LIBAV_INCLUDE_DEST}/libavfilter
-  ${LIBAV_INCLUDE_DEST}/libavformat ${LIBAV_INCLUDE_DEST}/libavresample
-  ${LIBAV_INCLUDE_DEST}/libavutil ${LIBAV_INCLUDE_DEST}/libswscale
-)
-
-set (LIBS_DEREF "")
-foreach (_file ${LIBAV_LIBS})
-    get_filename_component(_resolvedFile "${_file}" REALPATH)
-    list (APPEND LIBS_DEREF "${_resolvedFile}")
+set (LIBAV_LIBS "")
+set (LIBAV_INCLUDE_DIRS "")
+foreach (_name ${LIBAV_COMPONENTS})
+    #find_library(_library_file
+    #  NAMES ${_name}
+    #  PATHS ${LIBAV_LIBRARY_DEST}
+    #  NO_DEFAULT_PATH
+    #)
+    #list (APPEND LIBAV_LIBS "${_library_file}")
+    list (APPEND LIBAV_LIBS "${LIBAV_LIBRARY_DEST}/lib${_name}.so")
+    list (APPEND LIBAV_INCLUDE_DIRS "${LIBAV_INCLUDE_DEST}/lib${_name}")
 endforeach()
 
-target_link_libraries(libav_wrap ${LIBAV_LIBS})
+#target_link_libraries(libav_wrap -Wl,--whole-archive ${LIBAV_LIBS} -Wl,--no-whole-archive)
 add_dependencies(libav_wrap libav_trunk)
+target_link_libraries(libav_wrap ${LIBAV_LIBS})
 
 install(TARGETS libav_wrap
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
@@ -59,6 +54,15 @@ install(DIRECTORY ${LIBAV_INCLUDE_DIRS}
   DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}
 )
 
-install(FILES ${LIBS_DEREF}
-  DESTINATION ${CATKIN_GLOBAL_LIB_DESTINATION}
-)
+#install(DIRECTORY ${LIBAV_LIBRARY_DEST}/.
+#  DESTINATION ${CATKIN_GLOBAL_LIB_DESTINATION}
+#  EXPORT_LINK_INTERFACE_LIBRARIES
+#)
+
+foreach (_name ${LIBAV_COMPONENTS})
+  install(DIRECTORY ${LIBAV_LIBRARY_DEST}/.
+    RUNTIME DESTINATION ${CATKIN_GLOBAL_LIB_DESTINATION}
+    FILES_MATCHING
+    PATTERN "*${_name}*"
+  )
+endforeach()

--- a/catkinized_libav/package.xml
+++ b/catkinized_libav/package.xml
@@ -30,7 +30,7 @@
   <!-- Examples: -->
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>yasm</build_depend>
-  <build_depend>libx264-dev</build_depend>
+  <!-- <build_depend>libx264-dev</build_depend> -->
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/libav_image_transport/CMakeLists.txt
+++ b/libav_image_transport/CMakeLists.txt
@@ -142,7 +142,6 @@ add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencpp ${PROJECT_NAME}_gencfg)
 target_link_libraries(${PROJECT_NAME}
   ${catkin_LIBRARIES}
   ${Boost_LIBRARIES}
-#  ${LIBAV_LIBRARIES}
 )
 
 class_loader_hide_library_symbols(${PROJECT_NAME})


### PR DESCRIPTION
This adds install targets for `catkinized_libav`. It's now possible to run all the packages from the install directory.
