### PR TITLE
[mongodb_openni_compression] Add logging to mongodb

### DIFF
--- a/mongodb_openni_compression/CMakeLists.txt
+++ b/mongodb_openni_compression/CMakeLists.txt
@@ -1,7 +1,22 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(mongodb_openni_compression)
 
-find_package(catkin REQUIRED)
+find_package(catkin REQUIRED COMPONENTS
+  actionlib
+  actionlib_msgs
+  rospy)
+  
+## Generate actions in the 'action' folder
+add_action_files(
+  FILES
+  RecordCamera.action
+)
+
+## Generate added messages and services with any dependencies listed here
+generate_messages(
+  DEPENDENCIES
+  actionlib_msgs
+)
 
 catkin_package(
 # INCLUDE_DIRS include

--- a/mongodb_openni_compression/CMakeLists.txt
+++ b/mongodb_openni_compression/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(mongodb_openni_compression)
+
+find_package(catkin REQUIRED)
+
+catkin_package(
+# INCLUDE_DIRS include
+# LIBRARIES strands_utils
+# CATKIN_DEPENDS other_catkin_pkg
+# DEPENDS system_lib
+)
+
+install(DIRECTORY launch/
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/mongodb_openni_compression/CMakeLists.txt
+++ b/mongodb_openni_compression/CMakeLists.txt
@@ -25,6 +25,10 @@ catkin_package(
 # DEPENDS system_lib
 )
 
-install(DIRECTORY launch/
+install(DIRECTORY launch
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
+catkin_install_python(PROGRAMS scripts/record_server.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )

--- a/mongodb_openni_compression/action/RecordCamera.action
+++ b/mongodb_openni_compression/action/RecordCamera.action
@@ -1,0 +1,8 @@
+# the time to wait until
+string camera
+bool with_depth
+bool with_rgb
+---
+---
+# feedback message
+bool ready

--- a/mongodb_openni_compression/launch/record.launch
+++ b/mongodb_openni_compression/launch/record.launch
@@ -6,8 +6,8 @@
     <arg name="with_rgb" default="true"/>
     
     <!-- Topics for compressed depth and rgb -->
-    <arg name="compressed_depth" default="/compressed_depth2"/>
-    <arg name="compressed_rgb" default="/compressed_rgb2"/>
+    <arg name="compressed_depth" default="/compressed_depth"/>
+    <arg name="compressed_rgb" default="/compressed_rgb"/>
     
     <node pkg="image_transport" type="republish" name="$(arg camera)_depth_compressor" output="screen" args="raw in:=/$(arg camera)/depth/image_raw libav out:=$(arg compressed_depth)" if="$(arg with_depth)"/>
     <node pkg="image_transport" type="republish" name="$(arg camera)_rgb_compressor" output="screen" args="raw in:=/$(arg camera)/rgb/image_raw theora out:=$(arg compressed_rgb)" if="$(arg with_rgb)"/>
@@ -17,5 +17,8 @@
     <arg name="rgb_logger" value="mongodb_$(arg camera)_rgb_logger"/>
     <node pkg="mongodb_log" type="mongodb_log.py" name="$(arg rgb_logger)" args="--nodename-prefix=$(arg rgb_logger) $(arg compressed_rgb)/theora" output="screen" if="$(arg with_depth)"/>
     <node pkg="mongodb_log" type="mongodb_log.py" name="$(arg depth_logger)" args="--nodename-prefix=$(arg depth_logger) $(arg compressed_depth)/libav" output="screen" if="$(arg with_rgb)"/>
+    
+    <!-- For recording camera_info also, does not work atm -->
+
     
 </launch>

--- a/mongodb_openni_compression/launch/record.launch
+++ b/mongodb_openni_compression/launch/record.launch
@@ -1,0 +1,21 @@
+<launch>
+    
+    <!-- Camera namespace to save -->
+    <arg name="camera" default="head_xtion"/>
+    <arg name="with_depth" default="true"/>
+    <arg name="with_rgb" default="true"/>
+    
+    <!-- Topics for compressed depth and rgb -->
+    <arg name="compressed_depth" default="/compressed_depth2"/>
+    <arg name="compressed_rgb" default="/compressed_rgb2"/>
+    
+    <node pkg="image_transport" type="republish" name="$(arg camera)_depth_compressor" output="screen" args="raw in:=/$(arg camera)/depth/image_raw libav out:=$(arg compressed_depth)" if="$(arg with_depth)"/>
+    <node pkg="image_transport" type="republish" name="$(arg camera)_rgb_compressor" output="screen" args="raw in:=/$(arg camera)/rgb/image_raw theora out:=$(arg compressed_rgb)" if="$(arg with_rgb)"/>
+    
+    <!-- Record a rosbag, use regular expressions to exclude images -->
+    <arg name="depth_logger" value="mongodb_$(arg camera)_depth_logger"/>
+    <arg name="rgb_logger" value="mongodb_$(arg camera)_rgb_logger"/>
+    <node pkg="mongodb_log" type="mongodb_log.py" name="$(arg rgb_logger)" args="--nodename-prefix=$(arg rgb_logger) $(arg compressed_rgb)/theora" output="screen" if="$(arg with_depth)"/>
+    <node pkg="mongodb_log" type="mongodb_log.py" name="$(arg depth_logger)" args="--nodename-prefix=$(arg depth_logger) $(arg compressed_depth)/libav" output="screen" if="$(arg with_rgb)"/>
+    
+</launch>

--- a/mongodb_openni_compression/launch/record_server.launch
+++ b/mongodb_openni_compression/launch/record_server.launch
@@ -1,0 +1,4 @@
+<launch>
+    <node pkg="roslaunch_axserver" type="roslaunch_server.py" name="record_roslaunch_axserver" output="screen"/>
+    <node pkg="mongodb_openni_compression" type="record_server.py" name="record_camera" output="screen"/>
+</launch>

--- a/mongodb_openni_compression/package.xml
+++ b/mongodb_openni_compression/package.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+<package>
+  <name>mongodb_openni_compression</name>
+  <version>0.0.9</version>
+  <description>launch theora compression of the image stream and log it to the mongodb database</description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
+  <!-- Example:  -->
+  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <maintainer email="nbore@kth.se">Nils Bore</maintainer>
+
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>MIT</license>
+
+
+  <!-- Url tags are optional, but mutiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://wiki.ros.org/roslaunch_axserver</url> -->
+
+
+  <!-- Author tags are optional, mutiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintianers, but could be -->
+  <!-- Example: -->
+  <author email="nbore@kth.se">Nils Bore</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <run_depend>mongodb_log</run_depend>
+  <run_depend>mongodb_store</run_depend>
+  <run_depend>libav_image_transport</run_depend>
+  <run_depend>image_transport_plugins</run_depend>
+  <run_depend>openni_wrapper</run_depend>
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- You can specify that this package is a metapackage here: -->
+    <!-- <metapackage/> -->
+
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>

--- a/mongodb_openni_compression/package.xml
+++ b/mongodb_openni_compression/package.xml
@@ -33,6 +33,15 @@
   <run_depend>libav_image_transport</run_depend>
   <run_depend>image_transport_plugins</run_depend>
   <run_depend>openni_wrapper</run_depend>
+  
+  <build_depend>message_generation</build_depend>
+  <build_depend>actionlib</build_depend>
+  <build_depend>actionlib_msgs</build_depend>
+  <build_depend>rospy</build_depend>
+  <run_depend>message_runtime</run_depend>
+  <run_depend>actionlib</run_depend>
+  <run_depend>actionlib_msgs</run_depend>
+  <run_depend>rospy</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/mongodb_openni_compression/package.xml
+++ b/mongodb_openni_compression/package.xml
@@ -42,6 +42,7 @@
   <run_depend>actionlib</run_depend>
   <run_depend>actionlib_msgs</run_depend>
   <run_depend>rospy</run_depend>
+  <run_depend>roslaunch_axserver</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/mongodb_openni_compression/scripts/record_server.py
+++ b/mongodb_openni_compression/scripts/record_server.py
@@ -1,0 +1,51 @@
+#! /usr/bin/env python
+
+import rospy
+#import subprocess
+#import sys
+#import threading
+
+import actionlib
+from mongodb_openni_compression.msg import RecordCameraAction, RecordCameraResult, RecordCameraFeedback
+from roslaunch_axserver.msg import launchAction, launchGoal, launchResult, launchFeedback
+
+class RoslaunchServer(object):
+# create messages that are used to publish feedback/result
+
+    def __init__(self, name):
+        self._action_name = name
+        self.roslaunch_axclient = actionlib.SimpleActionClient('/launchServer', launchAction)
+        rospy.loginfo("Waiting for roslaunch action...") 
+        self.roslaunch_axclient.wait_for_server()
+        rospy.loginfo("Done") 
+        self.server = actionlib.ActionServer(name, RecordCameraAction, self.execute_cb, self.cancel_cb)
+        self.server.start()
+        rospy.loginfo("/record_camera action server started...")
+
+    def cancel_cb(self, gh):
+        self.roslaunch_axclient.cancel_all_goals()
+        gh.set_canceled()
+
+    def execute_cb(self, gh):
+        gh.set_accepted()
+        mygoal = gh.get_goal()
+        goal = launchGoal()
+        goal.pkg = "mongodb_openni_compression"
+        goal.launch_file = "record.launch camera:=" + mygoal.camera
+        if mygoal.with_depth:
+            goal.launch_file = goal.launch_file + " with_depth:=true"
+        if mygoal.with_rgb:
+            goal.launch_file = goal.launch_file + " with_rgb:=true"
+        print goal.pkg + " " + goal.launch_file
+        self.roslaunch_axclient.send_goal(goal)
+        #while (gh.get_goal_status().status == actionlib.GoalStatus.ACTIVE
+               # and not rospy.is_shutdown()):
+            #feedback = RecordCameraFeedback()
+            #feedback.ready = self.roslaunch_axclient.get_state() == actionlib.GoalStatus.ACTIVE
+            #gh.publish_feedback(feedback)
+            #rospy.sleep(1.0)
+
+if __name__ == '__main__':
+    rospy.init_node('record_camera')
+    RoslaunchServer(rospy.get_name())
+    rospy.spin()

--- a/mongodb_openni_compression/scripts/record_server.py
+++ b/mongodb_openni_compression/scripts/record_server.py
@@ -14,7 +14,7 @@ class RoslaunchServer(object):
 
     def __init__(self, name):
         self._action_name = name
-        self.roslaunch_axclient = actionlib.SimpleActionClient('/launchServer', launchAction)
+        self.roslaunch_axclient = actionlib.SimpleActionClient('/record_roslaunch_axserver', launchAction)
         rospy.loginfo("Waiting for roslaunch action...") 
         self.roslaunch_axclient.wait_for_server()
         rospy.loginfo("Done") 
@@ -32,10 +32,10 @@ class RoslaunchServer(object):
         goal = launchGoal()
         goal.pkg = "mongodb_openni_compression"
         goal.launch_file = "record.launch camera:=" + mygoal.camera
-        if mygoal.with_depth:
-            goal.launch_file = goal.launch_file + " with_depth:=true"
-        if mygoal.with_rgb:
-            goal.launch_file = goal.launch_file + " with_rgb:=true"
+        if not mygoal.with_depth:
+            goal.launch_file = goal.launch_file + " with_depth:=false"
+        if not mygoal.with_rgb:
+            goal.launch_file = goal.launch_file + " with_rgb:=false"
         print goal.pkg + " " + goal.launch_file
         self.roslaunch_axclient.send_goal(goal)
         #while (gh.get_goal_status().status == actionlib.GoalStatus.ACTIVE

--- a/rosbag_openni_compression/CMakeLists.txt
+++ b/rosbag_openni_compression/CMakeLists.txt
@@ -10,6 +10,6 @@ catkin_package(
 # DEPENDS system_lib
 )
 
-install(DIRECTORY launch/
+install(DIRECTORY launch
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )


### PR DESCRIPTION
This:
- Adds an action server `/record_camera` that enables temporary logging to the mongodb database.
- Launch everything by `roslaunch mongodb_openni_compression record_server.launch`
- Saves rgb image in `/rgb_compressed`, depth in `/depth_compressed`

Will add a replay launch file as soon as https://github.com/strands-project/mongodb_store/issues/116 is fixed.
Will also look at handling shutdown of `roslaunch_axserver` and feedback from it. However, this is a starting point that should work and has the general structure.
