### PR TITLE
[mongodb_openni_compression] Change default rgb compression to compressed

### DIFF
--- a/mongodb_openni_compression/launch/record.launch
+++ b/mongodb_openni_compression/launch/record.launch
@@ -17,8 +17,8 @@
     <!-- Record a rosbag, use regular expressions to exclude images -->
     <arg name="depth_logger" value="mongodb_$(arg camera)_depth_logger"/>
     <arg name="rgb_logger" value="mongodb_$(arg camera)_rgb_logger"/>
-    <node pkg="mongodb_log" type="mongodb_log.py" name="$(arg rgb_logger)" args="--nodename-prefix=$(arg rgb_logger) $(arg compressed_rgb)/theora" output="screen" if="$(arg with_depth)"/>
-    <node pkg="mongodb_log" type="mongodb_log.py" name="$(arg depth_logger)" args="--nodename-prefix=$(arg depth_logger) $(arg compressed_depth)/libav" output="screen" if="$(arg with_rgb)"/>
+    <node pkg="mongodb_log" type="mongodb_log.py" name="$(arg rgb_logger)" args="--nodename-prefix=$(arg rgb_logger) $(arg compressed_rgb)/$(arg rgb_compression)" output="screen" if="$(arg with_depth)"/>
+    <node pkg="mongodb_log" type="mongodb_log.py" name="$(arg depth_logger)" args="--nodename-prefix=$(arg depth_logger) $(arg compressed_depth)/$(arg depth_compression)" output="screen" if="$(arg with_rgb)"/>
     
     <!-- For recording camera_info also, does not work atm -->
 

--- a/mongodb_openni_compression/launch/record.launch
+++ b/mongodb_openni_compression/launch/record.launch
@@ -4,13 +4,15 @@
     <arg name="camera" default="head_xtion"/>
     <arg name="with_depth" default="true"/>
     <arg name="with_rgb" default="true"/>
+    <arg name="depth_compression" default="libav"/>
+    <arg name="rgb_compression" default="compressed"/>
     
     <!-- Topics for compressed depth and rgb -->
     <arg name="compressed_depth" default="/$(arg camera)_compressed_depth"/>
     <arg name="compressed_rgb" default="/$(arg camera)_compressed_rgb"/>
     
-    <node pkg="image_transport" type="republish" name="$(arg camera)_depth_compressor" output="screen" args="raw in:=/$(arg camera)/depth/image_raw libav out:=$(arg compressed_depth)" if="$(arg with_depth)"/>
-    <node pkg="image_transport" type="republish" name="$(arg camera)_rgb_compressor" output="screen" args="raw in:=/$(arg camera)/rgb/image_raw theora out:=$(arg compressed_rgb)" if="$(arg with_rgb)"/>
+    <node pkg="image_transport" type="republish" name="$(arg camera)_depth_compressor" output="screen" args="raw in:=/$(arg camera)/depth/image_raw $(arg depth_compression) out:=$(arg compressed_depth)" if="$(arg with_depth)"/>
+    <node pkg="image_transport" type="republish" name="$(arg camera)_rgb_compressor" output="screen" args="raw in:=/$(arg camera)/rgb/image_raw $(arg rgb_compression) out:=$(arg compressed_rgb)" if="$(arg with_rgb)"/>
     
     <!-- Record a rosbag, use regular expressions to exclude images -->
     <arg name="depth_logger" value="mongodb_$(arg camera)_depth_logger"/>


### PR DESCRIPTION
Since theora does not seem to reliable on the robot, I've changed the default compression of RGB to the ros compression. This can easily be switched later if needed, hopefully to the h264 codec (can be created by `libav_image_transport`) if that is deemed more reliable. @marc-hanheide Ping for re-release?
