### PR TITLE
[rosbag_openni_compression] Changed default rgb compression for rosbag

### DIFF
--- a/rosbag_openni_compression/launch/play.launch
+++ b/rosbag_openni_compression/launch/play.launch
@@ -4,42 +4,44 @@
     <rosparam>
         use_sim_time : true
     </rosparam>
-    
+
     <arg name="manager" default="manager"/>
     <arg name="machine" default="localhost"/>
     <arg name="user"   	default=""/>
-    
+
     <machine name="$(arg machine)" address="$(arg machine)" env-loader="/opt/strands/strands_catkin_ws/devel/env.sh" user="$(arg user)"/>
-    
+
     <!-- Camera namespace to save -->
     <arg name="camera" default="head_xtion"/>
-    
+
     <!-- Topics for compressed depth and rgb -->
     <arg name="compressed_depth" default="/compressed_depth"/>
     <arg name="compressed_rgb" default="/compressed_rgb"/>
-    
+    <arg name="depth_compression" default="libav"/>
+    <arg name="rgb_compression" default="compressed"/>
+
     <!-- The folder where the rosbag is stored together with the videos -->
     <arg name="file"/>
-    
+
     <!--
     <node pkg="image_transport" type="republish" name="depth_decompressor" output="screen" args="libav raw">
 	    <param name="in" type="str" value="$(arg compressed_depth)"/>
 	    <param name="out" type="str" value="/$(arg camera)/depth/image_raw"/>
     </node>
     -->
-    <node pkg="image_transport" type="republish" name="depth_decompressor" output="screen" args="libav in:=$(arg compressed_depth) raw out:=/$(arg camera)/depth/image_raw"/>
-    
+    <node pkg="image_transport" type="republish" name="depth_decompressor" output="screen" args="$(arg depth_compression) in:=$(arg compressed_depth) raw out:=/$(arg camera)/depth/image_raw"/>
+
     <!--
     <node pkg="image_transport" type="republish" name="rgb_decompressor" output="screen" args="theora raw">
 	    <param name="in" type="str" value="$(arg compressed_rgb)"/>
 	    <param name="out" type="str" value="/$(arg camera)/rgb/image_raw"/>
     </node>
     -->
-    <node pkg="image_transport" type="republish" name="rgb_decompressor" output="screen" args="theora in:=$(arg compressed_rgb) raw out:=/$(arg camera)/rgb/image_raw"/>
-    
+    <node pkg="image_transport" type="republish" name="rgb_decompressor" output="screen" args="$(arg rgb_compression) in:=$(arg compressed_rgb) raw out:=/$(arg camera)/rgb/image_raw"/>
+
     <!-- Launch the rosbag -->
     <node pkg="rosbag" type="play" name="player" output="screen" args="$(arg file) --clock"/>
-    
+
     <!-- Run the whole openni_launch processing chain -->
     <include file="$(find openni_wrapper)/launch/processing.launch">
         <arg name="camera" value="$(arg camera)"/>
@@ -50,5 +52,5 @@
         <arg name="depth_camera_info" value="$(arg camera)/depth/camera_info"/>
         <arg name="machine" value="$(arg machine)"/>
     </include>
-	
+
 </launch>

--- a/rosbag_openni_compression/launch/record.launch
+++ b/rosbag_openni_compression/launch/record.launch
@@ -3,34 +3,36 @@
     <rosparam>
         use_sim_time : false
     </rosparam>
-    
+
     <!-- Camera namespace to save -->
     <arg name="camera" default="head_xtion"/>
-    
+
     <!-- Topics for compressed depth and rgb -->
     <arg name="compressed_depth" default="/compressed_depth"/>
     <arg name="compressed_rgb" default="/compressed_rgb"/>
-    
+    <arg name="depth_compression" default="libav"/>
+    <arg name="rgb_compression" default="compressed"/>
+
     <!-- The folder where the rosbag is stored together with the videos -->
     <arg name="file"/>
-    
+
     <!--
     <node pkg="image_transport" type="republish" name="depth_compressor" output="screen" args="raw libav">
 	    <param name="in" type="str" value="/$(arg camera)/depth/image_raw"/>
 	    <param name="out" type="str" value="$(arg compressed_depth)"/>
     </node>
     -->
-    <node pkg="image_transport" type="republish" name="depth_compressor" output="screen" args="raw in:=/$(arg camera)/depth/image_raw libav out:=$(arg compressed_depth)"/>
-    
+    <node pkg="image_transport" type="republish" name="depth_compressor" output="screen" args="raw in:=/$(arg camera)/depth/image_raw $(arg depth_compression) out:=$(arg compressed_depth)"/>
+
     <!--
     <node pkg="image_transport" type="republish" name="rgb_compressor" output="screen" args="raw theora">
 	    <param name="in" type="str" value="/$(arg camera)/rgb/image_raw"/>
 	    <param name="out" type="str" value="$(arg compressed_rgb)"/>
     </node>
     -->
-    <node pkg="image_transport" type="republish" name="rgb_compressor" output="screen" args="raw in:=/$(arg camera)/rgb/image_raw theora out:=$(arg compressed_rgb)"/>
-    
+    <node pkg="image_transport" type="republish" name="rgb_compressor" output="screen" args="raw in:=/$(arg camera)/rgb/image_raw $(arg rgb_compression) out:=$(arg compressed_rgb)"/>
+
     <!-- Record a rosbag, use regular expressions to exclude images -->
     <node pkg="rosbag" type="record" name="recorder" output="screen" args="-a -x &quot;/(head_xtion|chest_xtion)/(?!depth\/camera_info|rgb\/camera_info).*&quot; -O $(arg file)"/>
-    
+
 </launch>


### PR DESCRIPTION
Changed default rgb compression for rosbag and added compression launch parameters. The theora compression in ROS seems to be too shaky to be usable, better to use the default image compression as with `mongodb_openni_compression`. @RaresAmbrus Could you try this? Should be swappable with the system you are using now.
